### PR TITLE
feat: [Epic 2] 법정동코드 시드 + 실거래가 수집 API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 DATABASE_URL=postgresql://...          # pooled (애플리케이션용)
 DATABASE_URL_UNPOOLED=postgresql://...  # unpooled (마이그레이션용)
 
+# 공공데이터포털 (data.go.kr)
+PUBLIC_DATA_API_KEY=
+
 # Telegram
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/adapter-neon": "^7.6.0",
+        "@prisma/adapter-pg": "^7.6.0",
         "@prisma/client": "^7.6.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -25,6 +26,7 @@
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "next-themes": "^0.4.6",
+        "pg": "^8.20.0",
         "postcss": "^8.5.8",
         "prisma": "^7.6.0",
         "react": "19.2.4",
@@ -40,6 +42,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20.19.37",
+        "@types/pg": "^8.20.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -50,6 +53,7 @@
         "husky": "^9.1.7",
         "jsdom": "^29.0.1",
         "prettier": "^3.8.1",
+        "tsx": "^4.21.0",
         "typescript": "^5",
         "vitest": "^4.1.2"
       }
@@ -626,6 +630,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1652,6 +2098,18 @@
       "dependencies": {
         "@neondatabase/serverless": ">0.6.0 <2",
         "@prisma/driver-adapter-utils": "7.6.0",
+        "postgres-array": "3.0.4"
+      }
+    },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.6.0.tgz",
+      "integrity": "sha512-BjHNmJqqa42NqJSDPnXUfwUofWo8LJY7Ui2gqxN4DmAOb+H/gGKv+hln2Xq/1kSJXPW5AXMXuNiPDMpywvyIOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.6.0",
+        "@types/pg": "^8.16.0",
+        "pg": "^8.16.3",
         "postgres-array": "3.0.4"
       }
     },
@@ -5227,6 +5685,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6085,7 +6585,7 @@
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
       "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -8130,6 +8630,46 @@
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -8137,6 +8677,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -8168,6 +8717,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -8858,7 +9416,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -9288,6 +9846,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sqlstring": {
@@ -9878,6 +10445,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@prisma/adapter-neon": "^7.6.0",
+    "@prisma/adapter-pg": "^7.6.0",
     "@prisma/client": "^7.6.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
@@ -33,6 +34,7 @@
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "next-themes": "^0.4.6",
+    "pg": "^8.20.0",
     "postcss": "^8.5.8",
     "prisma": "^7.6.0",
     "react": "19.2.4",
@@ -48,6 +50,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20.19.37",
+    "@types/pg": "^8.20.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
@@ -58,6 +61,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.0.1",
     "prettier": "^3.8.1",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.2"
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,8 +30,8 @@ model ApartmentComplex {
   id            String   @id @default(cuid())
   regionCode    String   @map("region_code")    // 법정동코드 5자리
   name          String                          // 단지명 (래미안)
-  dong          String?                         // 법정동 (사직동)
-  jibun         String?                         // 지번
+  dong          String   @default("")              // 법정동 (사직동)
+  jibun         String   @default("")              // 지번
   roadAddress   String?  @map("road_address")   // 도로명주소
   totalUnits    Int?     @map("total_units")    // 총 세대수
   builtYear     Int?     @map("built_year")     // 건축년도

--- a/scripts/seed-regions.ts
+++ b/scripts/seed-regions.ts
@@ -1,0 +1,235 @@
+/**
+ * 법정동코드(시군구 5자리) 시드 스크립트
+ * 실행: npx tsx scripts/seed-regions.ts
+ */
+import { Pool } from 'pg';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '../src/generated/prisma/client';
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+
+const REGIONS: { code: string; sido: string; sigungu: string }[] = [
+  // ── 서울특별시 (25개 구) ──
+  { code: '11110', sido: '서울특별시', sigungu: '종로구' },
+  { code: '11140', sido: '서울특별시', sigungu: '중구' },
+  { code: '11170', sido: '서울특별시', sigungu: '용산구' },
+  { code: '11200', sido: '서울특별시', sigungu: '성동구' },
+  { code: '11215', sido: '서울특별시', sigungu: '광진구' },
+  { code: '11230', sido: '서울특별시', sigungu: '동대문구' },
+  { code: '11260', sido: '서울특별시', sigungu: '중랑구' },
+  { code: '11290', sido: '서울특별시', sigungu: '성북구' },
+  { code: '11305', sido: '서울특별시', sigungu: '강북구' },
+  { code: '11320', sido: '서울특별시', sigungu: '도봉구' },
+  { code: '11350', sido: '서울특별시', sigungu: '노원구' },
+  { code: '11380', sido: '서울특별시', sigungu: '은평구' },
+  { code: '11410', sido: '서울특별시', sigungu: '서대문구' },
+  { code: '11440', sido: '서울특별시', sigungu: '마포구' },
+  { code: '11470', sido: '서울특별시', sigungu: '양천구' },
+  { code: '11500', sido: '서울특별시', sigungu: '강서구' },
+  { code: '11530', sido: '서울특별시', sigungu: '구로구' },
+  { code: '11545', sido: '서울특별시', sigungu: '금천구' },
+  { code: '11560', sido: '서울특별시', sigungu: '영등포구' },
+  { code: '11590', sido: '서울특별시', sigungu: '동작구' },
+  { code: '11620', sido: '서울특별시', sigungu: '관악구' },
+  { code: '11650', sido: '서울특별시', sigungu: '서초구' },
+  { code: '11680', sido: '서울특별시', sigungu: '강남구' },
+  { code: '11710', sido: '서울특별시', sigungu: '송파구' },
+  { code: '11740', sido: '서울특별시', sigungu: '강동구' },
+
+  // ── 부산광역시 (16개 구·군) ──
+  { code: '26110', sido: '부산광역시', sigungu: '중구' },
+  { code: '26140', sido: '부산광역시', sigungu: '서구' },
+  { code: '26170', sido: '부산광역시', sigungu: '동구' },
+  { code: '26200', sido: '부산광역시', sigungu: '영도구' },
+  { code: '26230', sido: '부산광역시', sigungu: '부산진구' },
+  { code: '26260', sido: '부산광역시', sigungu: '동래구' },
+  { code: '26290', sido: '부산광역시', sigungu: '남구' },
+  { code: '26320', sido: '부산광역시', sigungu: '북구' },
+  { code: '26350', sido: '부산광역시', sigungu: '해운대구' },
+  { code: '26380', sido: '부산광역시', sigungu: '사하구' },
+  { code: '26410', sido: '부산광역시', sigungu: '금정구' },
+  { code: '26440', sido: '부산광역시', sigungu: '강서구' },
+  { code: '26470', sido: '부산광역시', sigungu: '연제구' },
+  { code: '26500', sido: '부산광역시', sigungu: '수영구' },
+  { code: '26530', sido: '부산광역시', sigungu: '사상구' },
+  { code: '26710', sido: '부산광역시', sigungu: '기장군' },
+
+  // ── 대구광역시 (8개 구·군) ──
+  { code: '27110', sido: '대구광역시', sigungu: '중구' },
+  { code: '27140', sido: '대구광역시', sigungu: '동구' },
+  { code: '27170', sido: '대구광역시', sigungu: '서구' },
+  { code: '27200', sido: '대구광역시', sigungu: '남구' },
+  { code: '27230', sido: '대구광역시', sigungu: '북구' },
+  { code: '27260', sido: '대구광역시', sigungu: '수성구' },
+  { code: '27290', sido: '대구광역시', sigungu: '달서구' },
+  { code: '27710', sido: '대구광역시', sigungu: '달성군' },
+
+  // ── 인천광역시 (10개 구·군) ──
+  { code: '28110', sido: '인천광역시', sigungu: '중구' },
+  { code: '28140', sido: '인천광역시', sigungu: '동구' },
+  { code: '28177', sido: '인천광역시', sigungu: '미추홀구' },
+  { code: '28185', sido: '인천광역시', sigungu: '연수구' },
+  { code: '28200', sido: '인천광역시', sigungu: '남동구' },
+  { code: '28237', sido: '인천광역시', sigungu: '부평구' },
+  { code: '28245', sido: '인천광역시', sigungu: '계양구' },
+  { code: '28260', sido: '인천광역시', sigungu: '서구' },
+  { code: '28710', sido: '인천광역시', sigungu: '강화군' },
+  { code: '28720', sido: '인천광역시', sigungu: '옹진군' },
+
+  // ── 광주광역시 (5개 구) ──
+  { code: '29110', sido: '광주광역시', sigungu: '동구' },
+  { code: '29140', sido: '광주광역시', sigungu: '서구' },
+  { code: '29155', sido: '광주광역시', sigungu: '남구' },
+  { code: '29170', sido: '광주광역시', sigungu: '북구' },
+  { code: '29200', sido: '광주광역시', sigungu: '광산구' },
+
+  // ── 대전광역시 (5개 구) ──
+  { code: '30110', sido: '대전광역시', sigungu: '동구' },
+  { code: '30140', sido: '대전광역시', sigungu: '중구' },
+  { code: '30170', sido: '대전광역시', sigungu: '서구' },
+  { code: '30200', sido: '대전광역시', sigungu: '유성구' },
+  { code: '30230', sido: '대전광역시', sigungu: '대덕구' },
+
+  // ── 울산광역시 (5개 구·군) ──
+  { code: '31110', sido: '울산광역시', sigungu: '중구' },
+  { code: '31140', sido: '울산광역시', sigungu: '남구' },
+  { code: '31170', sido: '울산광역시', sigungu: '동구' },
+  { code: '31200', sido: '울산광역시', sigungu: '북구' },
+  { code: '31710', sido: '울산광역시', sigungu: '울주군' },
+
+  // ── 세종특별자치시 ──
+  { code: '36110', sido: '세종특별자치시', sigungu: '세종특별자치시' },
+
+  // ── 경기도 (주요 시·구) ──
+  { code: '41111', sido: '경기도', sigungu: '수원시 장안구' },
+  { code: '41113', sido: '경기도', sigungu: '수원시 권선구' },
+  { code: '41115', sido: '경기도', sigungu: '수원시 팔달구' },
+  { code: '41117', sido: '경기도', sigungu: '수원시 영통구' },
+  { code: '41131', sido: '경기도', sigungu: '성남시 수정구' },
+  { code: '41133', sido: '경기도', sigungu: '성남시 중원구' },
+  { code: '41135', sido: '경기도', sigungu: '성남시 분당구' },
+  { code: '41150', sido: '경기도', sigungu: '의정부시' },
+  { code: '41171', sido: '경기도', sigungu: '안양시 만안구' },
+  { code: '41173', sido: '경기도', sigungu: '안양시 동안구' },
+  { code: '41190', sido: '경기도', sigungu: '부천시' },
+  { code: '41210', sido: '경기도', sigungu: '광명시' },
+  { code: '41220', sido: '경기도', sigungu: '평택시' },
+  { code: '41250', sido: '경기도', sigungu: '동두천시' },
+  { code: '41271', sido: '경기도', sigungu: '안산시 상록구' },
+  { code: '41273', sido: '경기도', sigungu: '안산시 단원구' },
+  { code: '41281', sido: '경기도', sigungu: '고양시 덕양구' },
+  { code: '41285', sido: '경기도', sigungu: '고양시 일산동구' },
+  { code: '41287', sido: '경기도', sigungu: '고양시 일산서구' },
+  { code: '41290', sido: '경기도', sigungu: '과천시' },
+  { code: '41310', sido: '경기도', sigungu: '구리시' },
+  { code: '41360', sido: '경기도', sigungu: '남양주시' },
+  { code: '41370', sido: '경기도', sigungu: '오산시' },
+  { code: '41390', sido: '경기도', sigungu: '시흥시' },
+  { code: '41410', sido: '경기도', sigungu: '군포시' },
+  { code: '41430', sido: '경기도', sigungu: '의왕시' },
+  { code: '41450', sido: '경기도', sigungu: '하남시' },
+  { code: '41461', sido: '경기도', sigungu: '용인시 처인구' },
+  { code: '41463', sido: '경기도', sigungu: '용인시 기흥구' },
+  { code: '41465', sido: '경기도', sigungu: '용인시 수지구' },
+  { code: '41480', sido: '경기도', sigungu: '파주시' },
+  { code: '41500', sido: '경기도', sigungu: '이천시' },
+  { code: '41550', sido: '경기도', sigungu: '김포시' },
+  { code: '41570', sido: '경기도', sigungu: '화성시' },
+  { code: '41590', sido: '경기도', sigungu: '광주시' },
+  { code: '41610', sido: '경기도', sigungu: '양주시' },
+  { code: '41630', sido: '경기도', sigungu: '포천시' },
+  { code: '41650', sido: '경기도', sigungu: '여주시' },
+  { code: '41670', sido: '경기도', sigungu: '연천군' },
+  { code: '41800', sido: '경기도', sigungu: '가평군' },
+  { code: '41820', sido: '경기도', sigungu: '양평군' },
+
+  // ── 강원특별자치도 (주요 시·군) ──
+  { code: '42110', sido: '강원특별자치도', sigungu: '춘천시' },
+  { code: '42130', sido: '강원특별자치도', sigungu: '원주시' },
+  { code: '42150', sido: '강원특별자치도', sigungu: '강릉시' },
+  { code: '42170', sido: '강원특별자치도', sigungu: '동해시' },
+  { code: '42190', sido: '강원특별자치도', sigungu: '태백시' },
+  { code: '42210', sido: '강원특별자치도', sigungu: '속초시' },
+  { code: '42230', sido: '강원특별자치도', sigungu: '삼척시' },
+
+  // ── 충청북도 (주요 시·군) ──
+  { code: '43110', sido: '충청북도', sigungu: '청주시 상당구' },
+  { code: '43111', sido: '충청북도', sigungu: '청주시 서원구' },
+  { code: '43112', sido: '충청북도', sigungu: '청주시 흥덕구' },
+  { code: '43113', sido: '충청북도', sigungu: '청주시 청원구' },
+  { code: '43130', sido: '충청북도', sigungu: '충주시' },
+  { code: '43150', sido: '충청북도', sigungu: '제천시' },
+
+  // ── 충청남도 (주요 시·군) ──
+  { code: '44130', sido: '충청남도', sigungu: '천안시 동남구' },
+  { code: '44131', sido: '충청남도', sigungu: '천안시 서북구' },
+  { code: '44150', sido: '충청남도', sigungu: '공주시' },
+  { code: '44180', sido: '충청남도', sigungu: '보령시' },
+  { code: '44200', sido: '충청남도', sigungu: '아산시' },
+  { code: '44210', sido: '충청남도', sigungu: '서산시' },
+
+  // ── 전북특별자치도 (주요 시·군) ──
+  { code: '45111', sido: '전북특별자치도', sigungu: '전주시 완산구' },
+  { code: '45113', sido: '전북특별자치도', sigungu: '전주시 덕진구' },
+  { code: '45130', sido: '전북특별자치도', sigungu: '군산시' },
+  { code: '45140', sido: '전북특별자치도', sigungu: '익산시' },
+
+  // ── 전라남도 (주요 시·군) ──
+  { code: '46110', sido: '전라남도', sigungu: '목포시' },
+  { code: '46130', sido: '전라남도', sigungu: '여수시' },
+  { code: '46150', sido: '전라남도', sigungu: '순천시' },
+
+  // ── 경상북도 (주요 시·군) ──
+  { code: '47111', sido: '경상북도', sigungu: '포항시 남구' },
+  { code: '47113', sido: '경상북도', sigungu: '포항시 북구' },
+  { code: '47130', sido: '경상북도', sigungu: '경주시' },
+  { code: '47150', sido: '경상북도', sigungu: '김천시' },
+  { code: '47170', sido: '경상북도', sigungu: '안동시' },
+  { code: '47190', sido: '경상북도', sigungu: '구미시' },
+
+  // ── 경상남도 (주요 시·군) ──
+  { code: '48121', sido: '경상남도', sigungu: '창원시 의창구' },
+  { code: '48123', sido: '경상남도', sigungu: '창원시 성산구' },
+  { code: '48125', sido: '경상남도', sigungu: '창원시 마산합포구' },
+  { code: '48127', sido: '경상남도', sigungu: '창원시 마산회원구' },
+  { code: '48129', sido: '경상남도', sigungu: '창원시 진해구' },
+  { code: '48170', sido: '경상남도', sigungu: '진주시' },
+  { code: '48220', sido: '경상남도', sigungu: '김해시' },
+  { code: '48240', sido: '경상남도', sigungu: '밀양시' },
+  { code: '48250', sido: '경상남도', sigungu: '거제시' },
+  { code: '48270', sido: '경상남도', sigungu: '양산시' },
+
+  // ── 제주특별자치도 (2개 시) ──
+  { code: '50110', sido: '제주특별자치도', sigungu: '제주시' },
+  { code: '50130', sido: '제주특별자치도', sigungu: '서귀포시' },
+];
+
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL_UNPOOLED });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  console.warn(`시드 데이터: ${REGIONS.length}개 시군구`);
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const r of REGIONS) {
+    try {
+      await prisma.region.upsert({
+        where: { code: r.code },
+        update: { sido: r.sido, sigungu: r.sigungu, fullName: `${r.sido} ${r.sigungu}` },
+        create: { code: r.code, sido: r.sido, sigungu: r.sigungu, fullName: `${r.sido} ${r.sigungu}` },
+      });
+      created++;
+    } catch (e) {
+      console.error(`실패: ${r.code} ${r.sido} ${r.sigungu}`, e);
+      skipped++;
+    }
+  }
+
+  console.warn(`완료: ${created}개 upsert, ${skipped}개 실패`);
+  await prisma.$disconnect();
+}
+
+main().catch(console.error);

--- a/src/app/api/collect/trades/route.ts
+++ b/src/app/api/collect/trades/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { fetchApartmentTrades } from '@/lib/public-data';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+/**
+ * POST /api/collect/trades?lawdCd=11680&dealYmd=202602
+ * 특정 지역+년월의 아파트 매매 실거래가를 수집합니다.
+ *
+ * 쿼리 파라미터:
+ *   lawdCd  - 법정동코드 5자리 (필수)
+ *   dealYmd - 계약년월 YYYYMM (필수)
+ *
+ * Authorization: Bearer {CRON_SECRET} 필수
+ */
+export async function POST(request: NextRequest) {
+  // 인증 확인
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const lawdCd = searchParams.get('lawdCd');
+  const dealYmd = searchParams.get('dealYmd');
+
+  if (!lawdCd || !dealYmd) {
+    return NextResponse.json(
+      { error: 'lawdCd와 dealYmd 파라미터가 필요합니다.' },
+      { status: 400 }
+    );
+  }
+
+  const startTime = Date.now();
+
+  try {
+    // 1. 공공데이터 API 호출
+    const rawTrades = await fetchApartmentTrades(lawdCd, dealYmd);
+
+    if (rawTrades.length === 0) {
+      return NextResponse.json({ data: { lawdCd, dealYmd, collected: 0, message: '거래 데이터 없음' } });
+    }
+
+    // 2. 단지별 그룹핑 + upsert
+    let created = 0;
+    let skipped = 0;
+
+    for (const trade of rawTrades) {
+      try {
+        // 단지 upsert
+        const dong = trade.dong || '';
+        const jibun = trade.jibun || '';
+
+        const complex = await prisma.apartmentComplex.upsert({
+          where: {
+            regionCode_name_dong_jibun: {
+              regionCode: lawdCd,
+              name: trade.aptName,
+              dong,
+              jibun,
+            },
+          },
+          update: {
+            builtYear: trade.buildYear || undefined,
+            roadAddress: trade.roadAddress || undefined,
+          },
+          create: {
+            regionCode: lawdCd,
+            name: trade.aptName,
+            dong,
+            jibun,
+            builtYear: trade.buildYear || null,
+            roadAddress: trade.roadAddress || null,
+          },
+        });
+
+        // 거래 데이터 upsert
+        const dealDate = new Date(
+          trade.dealYear,
+          trade.dealMonth - 1,
+          trade.dealDay
+        );
+
+        // 평당가 계산 (전용면적 ㎡ → 평)
+        const pyeong = trade.area / 3.3058;
+        const pricePerPyeong = Math.round(trade.price / pyeong);
+
+        await prisma.apartmentTrade.upsert({
+          where: {
+            complexId_dealDate_area_floor_price: {
+              complexId: complex.id,
+              dealDate,
+              area: trade.area,
+              floor: trade.floor,
+              price: trade.price,
+            },
+          },
+          update: {
+            dealType: trade.dealType,
+            canceledAt: trade.canceledAt,
+            registeredAt: trade.registeredAt,
+            pricePerPyeong,
+          },
+          create: {
+            complexId: complex.id,
+            dealYear: trade.dealYear,
+            dealMonth: trade.dealMonth,
+            dealDay: trade.dealDay,
+            dealDate,
+            area: trade.area,
+            floor: trade.floor,
+            price: trade.price,
+            pricePerPyeong,
+            dealType: trade.dealType,
+            canceledAt: trade.canceledAt,
+            registeredAt: trade.registeredAt,
+          },
+        });
+
+        created++;
+      } catch {
+        skipped++;
+      }
+    }
+
+    const duration = Date.now() - startTime;
+
+    // 3. 수집 로그 저장
+    await prisma.cronExecutionLog.create({
+      data: {
+        endpoint: `/api/collect/trades?lawdCd=${lawdCd}&dealYmd=${dealYmd}`,
+        status: skipped > 0 ? 'partial' : 'success',
+        duration,
+        recordCount: created,
+        errorCount: skipped,
+      },
+    });
+
+    return NextResponse.json({
+      data: {
+        lawdCd,
+        dealYmd,
+        total: rawTrades.length,
+        collected: created,
+        skipped,
+        duration: `${duration}ms`,
+      },
+    });
+  } catch (e) {
+    const duration = Date.now() - startTime;
+    const message = e instanceof Error ? e.message : 'Unknown error';
+
+    await prisma.cronExecutionLog.create({
+      data: {
+        endpoint: `/api/collect/trades?lawdCd=${lawdCd}&dealYmd=${dealYmd}`,
+        status: 'error',
+        duration,
+        detail: { error: message },
+      },
+    }).catch(() => {});
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/market/regions/route.ts
+++ b/src/app/api/market/regions/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/regions?sido=서울특별시
+ * 법정동코드 목록을 조회합니다.
+ */
+export async function GET(request: NextRequest) {
+  const sido = request.nextUrl.searchParams.get('sido');
+
+  const regions = await prisma.region.findMany({
+    where: sido ? { sido } : undefined,
+    orderBy: [{ sido: 'asc' }, { sigungu: 'asc' }],
+  });
+
+  return NextResponse.json({ data: regions });
+}

--- a/src/app/api/market/trades/route.ts
+++ b/src/app/api/market/trades/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/trades?regionCode=11680&year=2026&month=2&page=1&limit=50
+ * 실거래가 데이터를 조회합니다.
+ */
+export async function GET(request: NextRequest) {
+  const sp = request.nextUrl.searchParams;
+  const regionCode = sp.get('regionCode');
+  const complexId = sp.get('complexId');
+  const year = sp.get('year') ? parseInt(sp.get('year')!, 10) : undefined;
+  const month = sp.get('month') ? parseInt(sp.get('month')!, 10) : undefined;
+  const page = parseInt(sp.get('page') || '1', 10);
+  const limit = Math.min(parseInt(sp.get('limit') || '50', 10), 200);
+  const skip = (page - 1) * limit;
+
+  const where: Record<string, unknown> = {};
+
+  if (complexId) {
+    where.complexId = complexId;
+  } else if (regionCode) {
+    where.complex = { regionCode };
+  }
+
+  if (year) where.dealYear = year;
+  if (month) where.dealMonth = month;
+
+  const [trades, total] = await Promise.all([
+    prisma.apartmentTrade.findMany({
+      where,
+      include: {
+        complex: {
+          select: { name: true, dong: true, regionCode: true },
+        },
+      },
+      orderBy: { dealDate: 'desc' },
+      skip,
+      take: limit,
+    }),
+    prisma.apartmentTrade.count({ where }),
+  ]);
+
+  return NextResponse.json({
+    data: trades,
+    meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
+  });
+}

--- a/src/lib/public-data.ts
+++ b/src/lib/public-data.ts
@@ -1,0 +1,91 @@
+/**
+ * 공공데이터포털 아파트매매 실거래가 API
+ * https://www.data.go.kr — 국토교통부 아파트매매 실거래 상세 자료
+ */
+
+const API_BASE = 'http://openapi.molit.go.kr/OpenAPI_ToolInstall/service/rest/RTMSOBJSvc';
+
+export interface RawTrade {
+  dealYear: number;
+  dealMonth: number;
+  dealDay: number;
+  aptName: string;
+  dong: string;
+  jibun: string;
+  area: number; // 전용면적 (㎡)
+  floor: number;
+  price: number; // 만원
+  buildYear: number;
+  dealType: string | null;
+  canceledAt: string | null;
+  registeredAt: string | null;
+  roadAddress: string | null;
+}
+
+/**
+ * 특정 지역+년월의 아파트 매매 실거래가를 조회합니다.
+ */
+export async function fetchApartmentTrades(
+  lawdCd: string,
+  dealYmd: string
+): Promise<RawTrade[]> {
+  const apiKey = process.env.PUBLIC_DATA_API_KEY;
+  if (!apiKey) throw new Error('PUBLIC_DATA_API_KEY 환경변수가 설정되지 않았습니다.');
+
+  const url = new URL(`${API_BASE}/getRTMSDataSvcAptTradeDev`);
+  url.searchParams.set('serviceKey', apiKey);
+  url.searchParams.set('LAWD_CD', lawdCd);
+  url.searchParams.set('DEAL_YMD', dealYmd);
+  url.searchParams.set('pageNo', '1');
+  url.searchParams.set('numOfRows', '9999');
+
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(`API 요청 실패: ${res.status}`);
+
+  const text = await res.text();
+  return parseTradeXml(text);
+}
+
+function parseTradeXml(xml: string): RawTrade[] {
+  const items: RawTrade[] = [];
+
+  // <item> 블록 추출
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = itemRegex.exec(xml)) !== null) {
+    const block = match[1];
+    const get = (tag: string): string => {
+      const m = block.match(new RegExp(`<${tag}>([^<]*)</${tag}>`));
+      return m ? m[1].trim() : '';
+    };
+
+    const price = parseInt(get('거래금액').replace(/,/g, ''), 10);
+    const area = parseFloat(get('전용면적'));
+    const floor = parseInt(get('층'), 10);
+    const dealYear = parseInt(get('년'), 10);
+    const dealMonth = parseInt(get('월'), 10);
+    const dealDay = parseInt(get('일'), 10);
+
+    if (!price || !area || isNaN(floor) || !dealYear) continue;
+
+    items.push({
+      dealYear,
+      dealMonth,
+      dealDay,
+      aptName: get('아파트') || get('단지명') || '미상',
+      dong: get('법정동'),
+      jibun: get('지번'),
+      area,
+      floor,
+      price,
+      buildYear: parseInt(get('건축년도'), 10) || 0,
+      dealType: get('거래유형') || null,
+      canceledAt: get('해제사유발생일') || null,
+      registeredAt: get('등기일자') || null,
+      roadAddress: get('도로명') || null,
+    });
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary
- 법정동코드 160개 시군구 시드 데이터 구축 (전국 주요 시군구)
- 공공데이터포털 아파트매매 실거래가 API 연동
- 수집/조회 API 엔드포인트 구현

## Changes
- `scripts/seed-regions.ts` — 법정동코드 시드 스크립트 (160개 시군구, Neon DB 반영 완료)
- `src/lib/public-data.ts` — 공공데이터포털 아파트매매 실거래가 API 클라이언트 (XML 파싱)
- `POST /api/collect/trades` — 실거래가 수집 (CRON_SECRET 인증, 지역+년월 단위)
- `GET /api/market/trades` — 실거래가 조회 (지역/단지/년월 필터, 페이지네이션)
- `GET /api/market/regions` — 법정동코드 목록 조회
- `prisma/schema.prisma` — dong/jibun 필드 non-null default 변경

## Test
- `npm run build` 통과
- 법정동코드 160개 시드 완료 (DB 확인)
- 실거래가 수집은 PUBLIC_DATA_API_KEY 발급 후 테스트 가능

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 아파트 실거래가 데이터 수집 및 조회 기능 추가
  * 지역별(시도/시군구) 정보 검색 기능 추가
  * 공공 데이터 포털 연동으로 실시간 거래 데이터 제공

* **작업**
  * PostgreSQL 데이터베이스 지원 추가
  * 지역 정보 데이터 초기화 기능 구현
  * 외부 API 연동 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->