### PR TITLE
feat: [Epic 3] 대시보드 시장 개요

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/typography": "^0.5.19",
         "@vercel/analytics": "^2.0.1",
@@ -2356,6 +2357,50 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -2661,6 +2706,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
@@ -2752,6 +2828,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/typography": "^0.5.19",
     "@vercel/analytics": "^2.0.1",

--- a/src/app/(dashboard)/dashboard/_components/rate-summary-card.tsx
+++ b/src/app/(dashboard)/dashboard/_components/rate-summary-card.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import useSWR from 'swr';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Landmark } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Rate {
+  name: string;
+  nameKr: string;
+  rate: number;
+  change: number;
+  date: string;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export function RateSummaryCard() {
+  const { data, isLoading } = useSWR<{ data: Rate[] }>(
+    '/api/market/rates',
+    fetcher,
+    { refreshInterval: 600_000 }
+  );
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-3">
+        <CardTitle className="text-base">금리 현황</CardTitle>
+        <Landmark className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between animate-pulse">
+                <div className="h-4 w-20 rounded bg-muted" />
+                <div className="h-4 w-16 rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : !data?.data?.length ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            ECOS 연동 후 표시됩니다.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {data.data.map((rate) => (
+              <div key={rate.name} className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">{rate.nameKr}</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold">{rate.rate.toFixed(2)}%</span>
+                  {rate.change !== 0 && (
+                    <span
+                      className={cn(
+                        'text-xs font-medium',
+                        rate.change > 0 ? 'text-price-up' : 'text-price-down'
+                      )}
+                    >
+                      {rate.change > 0 ? '+' : ''}
+                      {rate.change.toFixed(0)}bp
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/_components/recent-trades-card.tsx
+++ b/src/app/(dashboard)/dashboard/_components/recent-trades-card.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import useSWR from 'swr';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+interface Trade {
+  id: string;
+  dealDate: string;
+  area: number;
+  floor: number;
+  price: number;
+  pricePerPyeong: number | null;
+  complex: {
+    name: string;
+    dong: string;
+    regionCode: string;
+  };
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export function RecentTradesCard() {
+  const { data, isLoading } = useSWR<{ data: Trade[] }>(
+    '/api/market/trades?limit=10',
+    fetcher,
+    { refreshInterval: 300_000 }
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">최근 실거래 내역</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 animate-pulse">
+                <div className="h-4 w-28 rounded bg-muted" />
+                <div className="h-4 w-16 rounded bg-muted" />
+                <div className="ml-auto h-4 w-20 rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : !data?.data?.length ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            수집된 거래 데이터가 없습니다.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {data.data.map((trade) => {
+              const priceInOk = (trade.price / 10000).toFixed(1);
+              const date = trade.dealDate.slice(0, 10);
+
+              return (
+                <div
+                  key={trade.id}
+                  className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-accent/50 transition-colors"
+                >
+                  <span className="font-medium truncate max-w-[140px]">
+                    {trade.complex.name}
+                  </span>
+                  <Badge variant="outline" className="text-[10px] shrink-0">
+                    {trade.area}㎡ · {trade.floor}층
+                  </Badge>
+                  <span className="ml-auto font-semibold text-primary shrink-0">
+                    {priceInOk}억
+                  </span>
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {date}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/_components/region-summary-card.tsx
+++ b/src/app/(dashboard)/dashboard/_components/region-summary-card.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import useSWR from 'swr';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Building2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface RegionSummary {
+  regionCode: string;
+  sido: string;
+  sigungu: string;
+  tradeCount: number;
+  avgPrice: number;
+  avgPricePerPyeong: number;
+  latestTrade: {
+    name: string;
+    price: number;
+    area: number;
+    dealDate: string;
+  } | null;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export function RegionSummaryCards() {
+  const { data, isLoading } = useSWR<{ data: RegionSummary[] }>(
+    '/api/market/summary/regions',
+    fetcher,
+    { refreshInterval: 300_000 }
+  );
+
+  if (isLoading || !data?.data) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="animate-pulse">
+            <CardContent className="p-4">
+              <div className="h-4 w-24 rounded bg-muted" />
+              <div className="mt-3 h-8 w-32 rounded bg-muted" />
+              <div className="mt-2 h-3 w-40 rounded bg-muted" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (data.data.length === 0) {
+    return (
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-2 py-8">
+          <Building2 className="h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            아직 수집된 거래 데이터가 없습니다.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            공공데이터 API 키 등록 후 실거래가를 수집하세요.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {data.data.map((region, idx) => (
+        <Card
+          key={region.regionCode}
+          className={cn('hover-lift animate-fade-up', `delay-${idx + 1}`)}
+        >
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium">
+              {region.sigungu}
+            </CardTitle>
+            <Badge variant="secondary" className="text-[10px]">
+              {region.sido.replace(/특별시|광역시|특별자치시|특별자치도|도$/, '')}
+            </Badge>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <p className="text-2xl font-bold">
+              {region.avgPricePerPyeong.toLocaleString()}
+              <span className="ml-1 text-sm font-normal text-muted-foreground">만원/평</span>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              거래 {region.tradeCount.toLocaleString()}건
+              · 평균 {(region.avgPrice / 10000).toFixed(1)}억
+            </p>
+            {region.latestTrade && (
+              <p className="text-xs text-muted-foreground">
+                최근: {region.latestTrade.name} {region.latestTrade.area}㎡{' '}
+                {(region.latestTrade.price / 10000).toFixed(1)}억
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/_components/stats-cards.tsx
+++ b/src/app/(dashboard)/dashboard/_components/stats-cards.tsx
@@ -1,0 +1,57 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Building2, TrendingUp, Landmark, MapPin } from 'lucide-react';
+import { prisma } from '@/lib/prisma';
+
+export async function StatsCards() {
+  const [regionCount, complexCount, tradeCount] = await Promise.all([
+    prisma.region.count(),
+    prisma.apartmentComplex.count(),
+    prisma.apartmentTrade.count(),
+  ]);
+
+  const stats = [
+    {
+      label: '수집 지역',
+      value: regionCount.toLocaleString(),
+      unit: '개 시군구',
+      icon: MapPin,
+    },
+    {
+      label: '아파트 단지',
+      value: complexCount.toLocaleString(),
+      unit: '개',
+      icon: Building2,
+    },
+    {
+      label: '실거래 건수',
+      value: tradeCount.toLocaleString(),
+      unit: '건',
+      icon: TrendingUp,
+    },
+    {
+      label: '기준금리',
+      value: '—',
+      unit: 'ECOS 연동 예정',
+      icon: Landmark,
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {stats.map((stat, idx) => (
+        <Card key={stat.label} className={`hover-lift animate-fade-up delay-${idx + 1}`}>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {stat.label}
+            </CardTitle>
+            <stat.icon className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stat.value}</div>
+            <p className="text-xs text-muted-foreground">{stat.unit}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/loading.tsx
+++ b/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,30 @@
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="h-8 w-32 animate-pulse rounded bg-muted" />
+        <div className="mt-2 h-4 w-56 animate-pulse rounded bg-muted" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-28 animate-pulse rounded-xl bg-muted/60" />
+        ))}
+      </div>
+
+      <div>
+        <div className="mb-3 h-6 w-40 animate-pulse rounded bg-muted" />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-32 animate-pulse rounded-xl bg-muted/60" />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="h-64 animate-pulse rounded-xl bg-muted/60" />
+        <div className="h-64 animate-pulse rounded-xl bg-muted/60" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,92 +1,43 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Building2, TrendingUp, Landmark, MapPin } from 'lucide-react';
+import { Suspense } from 'react';
+import { StatsCards } from './_components/stats-cards';
+import { RegionSummaryCards } from './_components/region-summary-card';
+import { RecentTradesCard } from './_components/recent-trades-card';
+import { RateSummaryCard } from './_components/rate-summary-card';
+
+export const dynamic = 'force-dynamic';
 
 export default function DashboardPage() {
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold tracking-tight">시장 개요</h1>
         <p className="text-muted-foreground">부동산 시장 현황을 한눈에 확인하세요.</p>
       </div>
 
-      {/* Summary cards */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card className="hover-lift">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              서울 아파트 매매지수
-            </CardTitle>
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground">데이터 수집 예정</p>
-          </CardContent>
-        </Card>
+      {/* Stats */}
+      <Suspense
+        fallback={
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-28 animate-pulse rounded-xl bg-muted/60" />
+            ))}
+          </div>
+        }
+      >
+        <StatsCards />
+      </Suspense>
 
-        <Card className="hover-lift">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              기준금리
-            </CardTitle>
-            <Landmark className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground">ECOS 연동 예정</p>
-          </CardContent>
-        </Card>
-
-        <Card className="hover-lift">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              이번 달 거래량
-            </CardTitle>
-            <Building2 className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground">실거래가 수집 후 집계</p>
-          </CardContent>
-        </Card>
-
-        <Card className="hover-lift">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              수집 지역
-            </CardTitle>
-            <MapPin className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">—</div>
-            <p className="text-xs text-muted-foreground">법정동코드 시드 후 표시</p>
-          </CardContent>
-        </Card>
+      {/* Region summaries */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold">지역별 거래 현황</h2>
+        <RegionSummaryCards />
       </div>
 
-      {/* Placeholder sections */}
+      {/* Bottom grid */}
       <div className="grid gap-4 lg:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">최근 실거래 내역</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Epic 2 (실거래가 데이터 수집) 완료 후 표시됩니다.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">금리 추이</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Epic 3 (ECOS 연동) 완료 후 차트가 표시됩니다.
-            </p>
-          </CardContent>
-        </Card>
+        <RecentTradesCard />
+        <RateSummaryCard />
       </div>
     </div>
   );

--- a/src/app/api/market/rates/route.ts
+++ b/src/app/api/market/rates/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/rates
+ * 최신 금리 데이터를 조회합니다.
+ */
+export async function GET() {
+  // 각 금리 유형별 최신 1건씩
+  const rates = await prisma.interestRate.findMany({
+    orderBy: { date: 'desc' },
+    distinct: ['name'],
+    take: 10,
+  });
+
+  return NextResponse.json({ data: rates });
+}

--- a/src/app/api/market/summary/regions/route.ts
+++ b/src/app/api/market/summary/regions/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/summary/regions
+ * 거래 데이터가 있는 지역별 요약 (평균가, 거래수, 최근 거래)
+ */
+export async function GET() {
+  // 거래가 있는 지역만 조회 (상위 12개)
+  const complexes = await prisma.apartmentComplex.findMany({
+    where: { trades: { some: {} } },
+    include: {
+      region: true,
+      trades: {
+        orderBy: { dealDate: 'desc' },
+        take: 1,
+        select: { price: true, area: true, dealDate: true },
+      },
+    },
+  });
+
+  // 지역별 그룹핑
+  const regionMap = new Map<
+    string,
+    {
+      regionCode: string;
+      sido: string;
+      sigungu: string;
+      trades: { price: number; area: number; pricePerPyeong: number }[];
+      latestTrade: { name: string; price: number; area: number; dealDate: string } | null;
+    }
+  >();
+
+  for (const complex of complexes) {
+    const key = complex.regionCode;
+    if (!regionMap.has(key)) {
+      regionMap.set(key, {
+        regionCode: key,
+        sido: complex.region.sido,
+        sigungu: complex.region.sigungu,
+        trades: [],
+        latestTrade: null,
+      });
+    }
+
+    const entry = regionMap.get(key)!;
+
+    for (const trade of complex.trades) {
+      const pyeong = trade.area / 3.3058;
+      const pricePerPyeong = Math.round(trade.price / pyeong);
+      entry.trades.push({ price: trade.price, area: trade.area, pricePerPyeong });
+
+      if (
+        !entry.latestTrade ||
+        new Date(trade.dealDate) > new Date(entry.latestTrade.dealDate)
+      ) {
+        entry.latestTrade = {
+          name: complex.name,
+          price: trade.price,
+          area: trade.area,
+          dealDate: new Date(trade.dealDate).toISOString(),
+        };
+      }
+    }
+  }
+
+  const summaries = Array.from(regionMap.values())
+    .map((r) => ({
+      regionCode: r.regionCode,
+      sido: r.sido,
+      sigungu: r.sigungu,
+      tradeCount: r.trades.length,
+      avgPrice: Math.round(r.trades.reduce((s, t) => s + t.price, 0) / r.trades.length),
+      avgPricePerPyeong: Math.round(
+        r.trades.reduce((s, t) => s + t.pricePerPyeong, 0) / r.trades.length
+      ),
+      latestTrade: r.latestTrade,
+    }))
+    .sort((a, b) => b.tradeCount - a.tradeCount)
+    .slice(0, 12);
+
+  return NextResponse.json({ data: summaries });
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -2,15 +2,40 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Building2, LayoutDashboard, Map, Landmark, TrendingUp } from 'lucide-react';
+import {
+  Building2,
+  LayoutDashboard,
+  Map,
+  Landmark,
+  TrendingUp,
+  Home,
+  CalendarDays,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { ScrollArea } from '@/components/ui/scroll-area';
 
-const navItems = [
-  { href: '/dashboard', label: '대시보드', icon: LayoutDashboard },
-  { href: '/dashboard/map', label: '지도 탐색', icon: Map },
-  { href: '/dashboard/apartments', label: '아파트', icon: Building2 },
-  { href: '/dashboard/rates', label: '금리 동향', icon: Landmark },
-  { href: '/dashboard/indices', label: '가격지수', icon: TrendingUp },
+const NAV_GROUPS = [
+  {
+    label: 'Overview',
+    items: [
+      { href: '/dashboard', label: '시장 개요', icon: LayoutDashboard, exact: true },
+      { href: '/dashboard/map', label: '지도 탐색', icon: Map },
+    ],
+  },
+  {
+    label: '부동산',
+    items: [
+      { href: '/dashboard/apartments', label: '아파트', icon: Building2 },
+      { href: '/dashboard/subscriptions', label: '청약', icon: CalendarDays },
+    ],
+  },
+  {
+    label: '경제',
+    items: [
+      { href: '/dashboard/rates', label: '금리 동향', icon: Landmark },
+      { href: '/dashboard/indices', label: '가격지수', icon: TrendingUp },
+    ],
+  },
 ];
 
 interface SidebarProps {
@@ -25,37 +50,45 @@ export function Sidebar({ onNavigate }: SidebarProps) {
       {/* Logo */}
       <div className="flex h-14 items-center gap-2 border-b px-4">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
-          <Building2 className="h-4 w-4 text-primary-foreground" />
+          <Home className="h-4 w-4 text-primary-foreground" />
         </div>
         <span className="text-lg font-bold tracking-tight">EstateLab</span>
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 space-y-1 p-3">
-        {navItems.map((item) => {
-          const isActive =
-            item.href === '/dashboard'
-              ? pathname === '/dashboard'
-              : pathname.startsWith(item.href);
+      <ScrollArea className="flex-1">
+        <nav className="space-y-4 p-3">
+          {NAV_GROUPS.map((group) => (
+            <div key={group.label} className="space-y-0.5">
+              <p className="px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60">
+                {group.label}
+              </p>
+              {group.items.map((item) => {
+                const isActive = item.exact
+                  ? pathname === item.href
+                  : pathname === item.href || pathname.startsWith(item.href + '/');
 
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={onNavigate}
-              className={cn(
-                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-              )}
-            >
-              <item.icon className="h-4 w-4" />
-              {item.label}
-            </Link>
-          );
-        })}
-      </nav>
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={onNavigate}
+                    className={cn(
+                      'flex items-center gap-3 rounded-xl px-2.5 py-[7px] text-[13px] font-medium transition-colors',
+                      isActive
+                        ? 'bg-primary text-primary-foreground shadow-sm'
+                        : 'text-foreground/60 hover:bg-accent'
+                    )}
+                  >
+                    <item.icon className="h-4 w-4" />
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </div>
+          ))}
+        </nav>
+      </ScrollArea>
     </div>
   );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary
- 대시보드 메인 화면 구현 (marketlab 패턴 — Suspense 스트리밍 + SWR 폴링)
- 사이드바 그룹 네비게이션 (Overview / 부동산 / 경제)
- 4개 위젯 카드 + 2개 API 엔드포인트

## Changes
- `src/components/sidebar.tsx` — 그룹화된 네비게이션 (marketlab 패턴: 그룹 레이블 + 아이콘 + active 하이라이트)
- `src/app/(dashboard)/dashboard/page.tsx` — Suspense 스트리밍으로 조합
- `_components/stats-cards.tsx` — 서버 컴포넌트, DB 실시간 집계 (지역·단지·거래 건수)
- `_components/region-summary-card.tsx` — SWR 5분 폴링, 지역별 평당가·거래수
- `_components/recent-trades-card.tsx` — SWR, 최근 거래 10건
- `_components/rate-summary-card.tsx` — SWR, 금리 현황 (ECOS 연동 대기)
- `GET /api/market/summary/regions` — 지역별 거래 요약
- `GET /api/market/rates` — 최신 금리 조회
- `loading.tsx` — 스켈레톤 UI

## Test
- `npm run build` 통과
- 데이터 없는 상태에서 empty state UI 정상 표시

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)