### PR TITLE
feat: [Epic 5] 아파트 리스트 + 단지 상세 페이지

### DIFF
--- a/src/app/(dashboard)/dashboard/apartments/[id]/_components/area-comparison.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/_components/area-comparison.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface AreaGroup {
+  area: number;
+  count: number;
+  avgPrice: number;
+  avgPricePerPyeong: number;
+}
+
+interface AreaComparisonProps {
+  areaGroups: AreaGroup[];
+}
+
+export function AreaComparison({ areaGroups }: AreaComparisonProps) {
+  if (areaGroups.length === 0) return null;
+
+  const maxPrice = Math.max(...areaGroups.map((g) => g.avgPrice));
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">면적별 비교</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {areaGroups.map((group) => {
+            const widthPct = (group.avgPrice / maxPrice) * 100;
+            const pyeong = Math.round(group.area / 3.3058);
+
+            return (
+              <div key={group.area} className="space-y-1">
+                <div className="flex items-center justify-between text-sm">
+                  <span>
+                    {group.area}㎡
+                    <span className="ml-1 text-muted-foreground">({pyeong}평)</span>
+                  </span>
+                  <span className="font-semibold">
+                    {(group.avgPrice / 10000).toFixed(1)}억
+                    <span className="ml-1 text-xs font-normal text-muted-foreground">
+                      ({group.count}건)
+                    </span>
+                  </span>
+                </div>
+                <div className="h-2 rounded-full bg-muted">
+                  <div
+                    className="h-2 rounded-full bg-primary/60 transition-all"
+                    style={{ width: `${widthPct}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/apartments/[id]/_components/price-chart.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/_components/price-chart.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+interface Trade {
+  dealDate: string;
+  price: number;
+  area: number;
+  floor: number;
+}
+
+interface PriceChartProps {
+  trades: Trade[];
+}
+
+export function PriceChart({ trades }: PriceChartProps) {
+  if (trades.length === 0) return null;
+
+  // 월별 평균가 계산
+  const monthlyMap = new Map<string, { total: number; count: number }>();
+  for (const t of trades) {
+    const key = t.dealDate.slice(0, 7); // YYYY-MM
+    const existing = monthlyMap.get(key);
+    if (existing) {
+      existing.total += t.price;
+      existing.count++;
+    } else {
+      monthlyMap.set(key, { total: t.price, count: 1 });
+    }
+  }
+
+  const monthly = Array.from(monthlyMap.entries())
+    .map(([month, { total, count }]) => ({
+      month,
+      avgPrice: Math.round(total / count),
+    }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+
+  if (monthly.length === 0) return null;
+
+  const maxPrice = Math.max(...monthly.map((m) => m.avgPrice));
+  const minPrice = Math.min(...monthly.map((m) => m.avgPrice));
+  const range = maxPrice - minPrice || 1;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">매매가 추이</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end gap-1 h-40">
+          {monthly.map((m, idx) => {
+            const height = ((m.avgPrice - minPrice) / range) * 100 + 10; // min 10%
+            const isLast = idx === monthly.length - 1;
+
+            return (
+              <div
+                key={m.month}
+                className="flex flex-1 flex-col items-center gap-1"
+              >
+                <span className="text-[10px] text-muted-foreground">
+                  {(m.avgPrice / 10000).toFixed(1)}억
+                </span>
+                <div
+                  className={cn(
+                    'w-full rounded-t transition-all',
+                    isLast ? 'bg-primary' : 'bg-primary/30'
+                  )}
+                  style={{ height: `${height}%` }}
+                />
+                <span className="text-[9px] text-muted-foreground">
+                  {m.month.slice(5)}월
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/apartments/[id]/_components/trade-table.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/_components/trade-table.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface Trade {
+  id: string;
+  dealDate: string;
+  area: number;
+  floor: number;
+  price: number;
+  pricePerPyeong: number | null;
+  dealType: string | null;
+}
+
+interface TradeTableProps {
+  trades: Trade[];
+}
+
+export function TradeTable({ trades }: TradeTableProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">거래 내역</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="pb-2 font-medium">거래일</th>
+                <th className="pb-2 font-medium">면적</th>
+                <th className="pb-2 font-medium">층</th>
+                <th className="pb-2 font-medium text-right">거래가</th>
+                <th className="pb-2 font-medium text-right">평당가</th>
+                <th className="pb-2 font-medium">유형</th>
+              </tr>
+            </thead>
+            <tbody>
+              {trades.map((trade) => (
+                <tr key={trade.id} className="border-b last:border-0 hover:bg-accent/50 transition-colors">
+                  <td className="py-2 text-muted-foreground">
+                    {trade.dealDate.slice(0, 10)}
+                  </td>
+                  <td className="py-2">{trade.area}㎡</td>
+                  <td className="py-2">{trade.floor}층</td>
+                  <td className="py-2 text-right font-semibold text-primary">
+                    {(trade.price / 10000).toFixed(1)}억
+                  </td>
+                  <td className="py-2 text-right text-muted-foreground">
+                    {trade.pricePerPyeong ? `${trade.pricePerPyeong.toLocaleString()}만` : '—'}
+                  </td>
+                  <td className="py-2">
+                    {trade.dealType && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {trade.dealType}
+                      </Badge>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
@@ -1,0 +1,158 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import { Card, CardContent } from '@/components/ui/card';
+import { Building2, MapPin, Calendar, ArrowLeft } from 'lucide-react';
+import { PriceChart } from './_components/price-chart';
+import { TradeTable } from './_components/trade-table';
+import { AreaComparison } from './_components/area-comparison';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ApartmentDetailPage({ params }: PageProps) {
+  const { id } = await params;
+
+  const complex = await prisma.apartmentComplex.findUnique({
+    where: { id },
+    include: {
+      region: true,
+      trades: {
+        orderBy: { dealDate: 'desc' },
+        take: 200,
+      },
+    },
+  });
+
+  if (!complex) notFound();
+
+  // 면적별 그룹핑
+  const areaMap = new Map<number, { count: number; totalPrice: number; totalPPP: number }>();
+  for (const trade of complex.trades) {
+    const areaKey = Math.round(trade.area);
+    const pyeong = trade.area / 3.3058;
+    const ppp = Math.round(trade.price / pyeong);
+    const existing = areaMap.get(areaKey);
+    if (existing) {
+      existing.count++;
+      existing.totalPrice += trade.price;
+      existing.totalPPP += ppp;
+    } else {
+      areaMap.set(areaKey, { count: 1, totalPrice: trade.price, totalPPP: ppp });
+    }
+  }
+
+  const areaGroups = Array.from(areaMap.entries())
+    .map(([area, { count, totalPrice, totalPPP }]) => ({
+      area,
+      count,
+      avgPrice: Math.round(totalPrice / count),
+      avgPricePerPyeong: Math.round(totalPPP / count),
+    }))
+    .sort((a, b) => a.area - b.area);
+
+  // 통계
+  const tradeCount = complex.trades.length;
+  const avgPrice = tradeCount
+    ? Math.round(complex.trades.reduce((s, t) => s + t.price, 0) / tradeCount)
+    : 0;
+  const latestTrade = complex.trades[0];
+
+  return (
+    <div className="space-y-6">
+      {/* Back + Header */}
+      <div>
+        <Link
+          href="/dashboard/apartments"
+          className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          목록으로
+        </Link>
+        <div className="flex items-start gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+            <Building2 className="h-6 w-6 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">{complex.name}</h1>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-3.5 w-3.5" />
+                {complex.region.sido} {complex.region.sigungu} {complex.dong}
+              </span>
+              {complex.builtYear && (
+                <span className="inline-flex items-center gap-1">
+                  <Calendar className="h-3.5 w-3.5" />
+                  {complex.builtYear}년 건축
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-sm text-muted-foreground">평균 매매가</p>
+            <p className="text-2xl font-bold text-primary">
+              {(avgPrice / 10000).toFixed(1)}
+              <span className="ml-1 text-sm font-normal text-muted-foreground">억</span>
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-sm text-muted-foreground">거래 건수</p>
+            <p className="text-2xl font-bold">{tradeCount}건</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-sm text-muted-foreground">최근 거래</p>
+            {latestTrade ? (
+              <div>
+                <p className="text-2xl font-bold">
+                  {(latestTrade.price / 10000).toFixed(1)}
+                  <span className="ml-1 text-sm font-normal text-muted-foreground">억</span>
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {latestTrade.area}㎡ · {latestTrade.floor}층 ·{' '}
+                  {latestTrade.dealDate.toISOString().slice(0, 10)}
+                </p>
+              </div>
+            ) : (
+              <p className="text-2xl font-bold text-muted-foreground">—</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Charts */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <PriceChart trades={complex.trades.map((t) => ({
+          dealDate: t.dealDate.toISOString(),
+          price: t.price,
+          area: t.area,
+          floor: t.floor,
+        }))} />
+        <AreaComparison areaGroups={areaGroups} />
+      </div>
+
+      {/* Trade table */}
+      <TradeTable trades={complex.trades.map((t) => ({
+        id: t.id,
+        dealDate: t.dealDate.toISOString(),
+        area: t.area,
+        floor: t.floor,
+        price: t.price,
+        pricePerPyeong: t.pricePerPyeong,
+        dealType: t.dealType,
+      }))} />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/apartments/page.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/page.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState } from 'react';
+import useSWR from 'swr';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Building2, ChevronRight, Search } from 'lucide-react';
+
+interface ApartmentItem {
+  id: string;
+  name: string;
+  dong: string;
+  regionCode: string;
+  region: { sido: string; sigungu: string };
+  builtYear: number | null;
+  tradeCount: number;
+  latestTrade: {
+    price: number;
+    area: number;
+    floor: number;
+    dealDate: string;
+  } | null;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export default function ApartmentsPage() {
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+
+  const searchParam = query ? `&q=${encodeURIComponent(query)}` : '';
+  const { data, isLoading } = useSWR<{
+    data: ApartmentItem[];
+    meta: { total: number; page: number; totalPages: number };
+  }>(`/api/market/apartments?page=${page}&limit=20${searchParam}`, fetcher);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">아파트</h1>
+        <p className="text-muted-foreground">실거래가가 수집된 아파트 단지 목록입니다.</p>
+      </div>
+
+      {/* 검색 */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <input
+          type="text"
+          placeholder="단지명으로 검색..."
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(1);
+          }}
+          className="w-full rounded-lg border bg-background py-2 pl-10 pr-4 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+        />
+      </div>
+
+      {/* 리스트 */}
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="h-20 animate-pulse rounded-xl bg-muted/60" />
+          ))}
+        </div>
+      ) : !data?.data?.length ? (
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center gap-2 py-8">
+            <Building2 className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              {query ? `"${query}" 검색 결과가 없습니다.` : '수집된 단지 데이터가 없습니다.'}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <div className="space-y-2">
+            {data.data.map((apt, idx) => (
+              <Link key={apt.id} href={`/dashboard/apartments/${apt.id}`}>
+                <Card className={`hover-lift animate-fade-up cursor-pointer delay-${Math.min(idx + 1, 8)}`}>
+                  <CardContent className="flex items-center gap-4 p-4">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                      <Building2 className="h-5 w-5 text-primary" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium truncate">{apt.name}</span>
+                        {apt.builtYear && (
+                          <Badge variant="outline" className="text-[10px] shrink-0">
+                            {apt.builtYear}년
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {apt.region.sigungu} {apt.dong} · 거래 {apt.tradeCount}건
+                      </p>
+                    </div>
+                    {apt.latestTrade && (
+                      <div className="text-right shrink-0">
+                        <p className="font-semibold text-primary">
+                          {(apt.latestTrade.price / 10000).toFixed(1)}억
+                        </p>
+                        <p className="text-[11px] text-muted-foreground">
+                          {apt.latestTrade.area}㎡ · {apt.latestTrade.floor}층
+                        </p>
+                      </div>
+                    )}
+                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          {/* 페이지네이션 */}
+          {data.meta.totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                이전
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {page} / {data.meta.totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(data.meta.totalPages, p + 1))}
+                disabled={page >= data.meta.totalPages}
+              >
+                다음
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/market/apartments/[id]/route.ts
+++ b/src/app/api/market/apartments/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/apartments/[id]
+ * 단지 상세 + 거래 내역
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const complex = await prisma.apartmentComplex.findUnique({
+    where: { id },
+    include: {
+      region: true,
+      trades: {
+        orderBy: { dealDate: 'desc' },
+        take: 200,
+      },
+    },
+  });
+
+  if (!complex) {
+    return NextResponse.json({ error: '단지를 찾을 수 없습니다.' }, { status: 404 });
+  }
+
+  // 면적별 그룹핑
+  const areaGroups = new Map<number, { count: number; avgPrice: number; avgPricePerPyeong: number }>();
+  for (const trade of complex.trades) {
+    const areaKey = Math.round(trade.area);
+    const existing = areaGroups.get(areaKey);
+    const pyeong = trade.area / 3.3058;
+    const ppp = Math.round(trade.price / pyeong);
+
+    if (existing) {
+      existing.count++;
+      existing.avgPrice = Math.round((existing.avgPrice * (existing.count - 1) + trade.price) / existing.count);
+      existing.avgPricePerPyeong = Math.round((existing.avgPricePerPyeong * (existing.count - 1) + ppp) / existing.count);
+    } else {
+      areaGroups.set(areaKey, { count: 1, avgPrice: trade.price, avgPricePerPyeong: ppp });
+    }
+  }
+
+  return NextResponse.json({
+    data: {
+      ...complex,
+      areaGroups: Array.from(areaGroups.entries())
+        .map(([area, stats]) => ({ area, ...stats }))
+        .sort((a, b) => a.area - b.area),
+    },
+  });
+}

--- a/src/app/api/market/apartments/route.ts
+++ b/src/app/api/market/apartments/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/apartments?regionCode=11680&q=래미안&page=1&limit=20
+ * 아파트 단지 목록 조회
+ */
+export async function GET(request: NextRequest) {
+  const sp = request.nextUrl.searchParams;
+  const regionCode = sp.get('regionCode');
+  const q = sp.get('q');
+  const page = parseInt(sp.get('page') || '1', 10);
+  const limit = Math.min(parseInt(sp.get('limit') || '20', 10), 100);
+  const skip = (page - 1) * limit;
+
+  const where: Record<string, unknown> = {};
+  if (regionCode) where.regionCode = regionCode;
+  if (q) where.name = { contains: q, mode: 'insensitive' };
+  // 거래가 있는 단지만
+  where.trades = { some: {} };
+
+  const [complexes, total] = await Promise.all([
+    prisma.apartmentComplex.findMany({
+      where,
+      include: {
+        region: { select: { sido: true, sigungu: true } },
+        _count: { select: { trades: true } },
+        trades: {
+          orderBy: { dealDate: 'desc' },
+          take: 1,
+          select: { price: true, area: true, dealDate: true, floor: true },
+        },
+      },
+      orderBy: { name: 'asc' },
+      skip,
+      take: limit,
+    }),
+    prisma.apartmentComplex.count({ where }),
+  ]);
+
+  const data = complexes.map((c) => {
+    const latest = c.trades[0];
+    return {
+      id: c.id,
+      name: c.name,
+      dong: c.dong,
+      regionCode: c.regionCode,
+      region: c.region,
+      builtYear: c.builtYear,
+      tradeCount: c._count.trades,
+      latestTrade: latest
+        ? {
+            price: latest.price,
+            area: latest.area,
+            floor: latest.floor,
+            dealDate: latest.dealDate,
+          }
+        : null,
+    };
+  });
+
+  return NextResponse.json({
+    data,
+    meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
+  });
+}


### PR DESCRIPTION
## Summary
- 아파트 단지 리스트 페이지 (검색 + 페이지네이션)
- 단지 상세 페이지 (가격 차트 + 면적별 비교 + 거래 내역 테이블)

## Changes

### 페이지
- `/dashboard/apartments` — 단지 리스트 (SWR, 단지명 검색, 페이지네이션)
- `/dashboard/apartments/[id]` — 단지 상세 (Server Component)
  - 통계 카드 3개 (평균 매매가, 거래 건수, 최근 거래)
  - 매매가 추이 바 차트 (월별 평균가)
  - 면적별 비교 (프로그레스 바 + 평균가)
  - 거래 내역 테이블 (날짜, 면적, 층, 가격, 평당가, 유형)

### API
- `GET /api/market/apartments` — 단지 목록 (검색, 페이지네이션)
- `GET /api/market/apartments/[id]` — 단지 상세 + 면적별 통계

## Test
- `npm run build` 통과
- 강남구 149건 수집 데이터로 리스트/상세 정상 표시

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **아파트 검색 및 목록 조회**
  * 아파트 검색 기능 추가 (검색어, 지역 필터링 지원)
  * 페이지네이션을 통한 검색 결과 탐색

* **아파트 상세 정보 페이지**
  * 월별 평균 거래가 추이 차트 표시
  * 면적별 거래 비교 정보 제공
  * 상세 거래 내역 테이블 표시
  * 총 거래 건수, 평균 가격 등 주요 통계 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->