### PR TITLE
fix: 대시보드 레이아웃 marketlab 패밀리 정렬

### DIFF
--- a/src/app/(dashboard)/_components/dashboard-shell.tsx
+++ b/src/app/(dashboard)/_components/dashboard-shell.tsx
@@ -6,22 +6,24 @@ import { Header } from '@/components/header';
 import { MobileSidebar } from '@/components/mobile-sidebar';
 
 export function DashboardShell({ children }: { children: React.ReactNode }) {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen overflow-hidden">
       {/* Desktop sidebar */}
-      <aside className="hidden w-60 shrink-0 border-r bg-sidebar lg:block">
+      <div className="hidden md:flex shrink-0">
         <Sidebar />
-      </aside>
+      </div>
 
       {/* Mobile sidebar */}
-      <MobileSidebar open={sidebarOpen} onOpenChange={setSidebarOpen} />
+      <MobileSidebar open={mobileOpen} onOpenChange={setMobileOpen} />
 
       {/* Main content */}
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <Header onMenuClick={() => setSidebarOpen(true)} />
-        <main className="flex-1 overflow-y-auto p-4 md:p-6">{children}</main>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Header onMenuClick={() => setMobileOpen(true)} />
+        <main className="flex-1 overflow-y-auto bg-background p-4 md:p-6">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -8,15 +9,50 @@ interface HeaderProps {
 }
 
 export function Header({ onMenuClick }: HeaderProps) {
+  const [now, setNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    const tick = () => setNow(new Date());
+    const id = setInterval(tick, 1000);
+    const t = setTimeout(tick, 0);
+    return () => {
+      clearInterval(id);
+      clearTimeout(t);
+    };
+  }, []);
+
+  const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+  const dateStr = now
+    ? `${now.getMonth() + 1}월 ${now.getDate()}일 (${WEEKDAYS[now.getDay()]})`
+    : '';
+  const timeStr = now
+    ? `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`
+    : '';
+
   return (
-    <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      {/* Mobile menu */}
-      <Button variant="ghost" size="icon" className="lg:hidden" onClick={onMenuClick}>
-        <Menu className="h-5 w-5" />
-        <span className="sr-only">메뉴 열기</span>
+    <header className="relative z-30 flex h-14 shrink-0 items-center border-b border-border/50 bg-card/90 backdrop-blur-sm px-4 md:px-6 gap-3">
+      {/* 모바일 메뉴 버튼 */}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="md:hidden h-8 w-8 shrink-0"
+        onClick={onMenuClick}
+        aria-label="메뉴 열기"
+      >
+        <Menu className="h-4 w-4" />
       </Button>
 
-      {/* Title area */}
+      {/* 실시간 날짜·시각 */}
+      {now && (
+        <div className="hidden md:flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="font-medium">{dateStr}</span>
+          <span className="tabular-nums font-mono text-foreground/70 font-semibold">
+            {timeStr}
+          </span>
+        </div>
+      )}
+
+      {/* spacer */}
       <div className="flex-1" />
     </header>
   );

--- a/src/components/mobile-sidebar.tsx
+++ b/src/components/mobile-sidebar.tsx
@@ -17,10 +17,10 @@ interface MobileSidebarProps {
 export function MobileSidebar({ open, onOpenChange }: MobileSidebarProps) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="left" className="w-72 p-0">
+      <SheetContent side="left" className="w-64 p-0" style={{ backgroundColor: 'white' }}>
         <VisuallyHidden>
-          <SheetTitle>내비게이션</SheetTitle>
-          <SheetDescription>EstateLab 메뉴</SheetDescription>
+          <SheetTitle>내비게이션 메뉴</SheetTitle>
+          <SheetDescription>대시보드 내비게이션</SheetDescription>
         </VisuallyHidden>
         <Sidebar onNavigate={() => onOpenChange(false)} />
       </SheetContent>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -10,9 +10,9 @@ import {
   TrendingUp,
   Home,
   CalendarDays,
+  Search,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { ScrollArea } from '@/components/ui/scroll-area';
 
 const NAV_GROUPS = [
   {
@@ -25,7 +25,7 @@ const NAV_GROUPS = [
   {
     label: '부동산',
     items: [
-      { href: '/dashboard/apartments', label: '아파트', icon: Building2 },
+      { href: '/dashboard/apartments', label: '아파트', icon: Building2, exact: true },
       { href: '/dashboard/subscriptions', label: '청약', icon: CalendarDays },
     ],
   },
@@ -38,31 +38,47 @@ const NAV_GROUPS = [
   },
 ];
 
-interface SidebarProps {
-  onNavigate?: () => void;
-}
-
-export function Sidebar({ onNavigate }: SidebarProps) {
+export function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname();
 
   return (
-    <div className="flex h-full flex-col">
+    <aside className="flex h-full w-[240px] flex-col bg-[hsl(var(--sidebar-background))] border-r border-border/40">
       {/* Logo */}
-      <div className="flex h-14 items-center gap-2 border-b px-4">
+      <Link href="/" className="flex h-16 items-center gap-2.5 px-5 hover:opacity-80 transition-opacity">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
           <Home className="h-4 w-4 text-primary-foreground" />
         </div>
-        <span className="text-lg font-bold tracking-tight">EstateLab</span>
+        <div className="flex flex-col">
+          <span className="text-[15px] font-semibold tracking-tight leading-none">
+            EstateLab
+          </span>
+          <span className="text-[10px] font-medium text-muted-foreground tracking-widest uppercase mt-0.5">
+            Real Estate Intelligence
+          </span>
+        </div>
+      </Link>
+
+      {/* Search trigger */}
+      <div className="px-4 pb-2">
+        <button
+          className="w-full flex items-center gap-2 rounded-xl h-8 px-2.5 bg-primary/[0.04] border border-primary/20 hover:border-primary/40 hover:bg-primary/[0.07] transition-all text-xs text-foreground/50 hover:text-foreground/80"
+        >
+          <Search className="h-3.5 w-3.5 shrink-0" />
+          <span className="flex-1 text-left">단지, 지역 검색...</span>
+          <kbd className="hidden sm:inline-flex items-center gap-0.5 font-mono text-[10px] bg-muted px-1 py-0.5 rounded">
+            ⌘K
+          </kbd>
+        </button>
       </div>
 
       {/* Navigation */}
-      <ScrollArea className="flex-1">
-        <nav className="space-y-4 p-3">
-          {NAV_GROUPS.map((group) => (
-            <div key={group.label} className="space-y-0.5">
-              <p className="px-2.5 pb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60">
-                {group.label}
-              </p>
+      <nav className="flex-1 overflow-y-auto px-3 pt-1 pb-2 space-y-4">
+        {NAV_GROUPS.map((group) => (
+          <div key={group.label}>
+            <p className="text-[10px] font-semibold text-foreground/40 uppercase tracking-widest px-2.5 mb-1">
+              {group.label}
+            </p>
+            <div className="space-y-0.5">
               {group.items.map((item) => {
                 const isActive = item.exact
                   ? pathname === item.href
@@ -74,21 +90,21 @@ export function Sidebar({ onNavigate }: SidebarProps) {
                     href={item.href}
                     onClick={onNavigate}
                     className={cn(
-                      'flex items-center gap-3 rounded-xl px-2.5 py-[7px] text-[13px] font-medium transition-colors',
+                      'flex items-center gap-2.5 rounded-xl px-2.5 py-[7px] text-[13px] font-medium transition-all duration-150',
                       isActive
                         ? 'bg-primary text-primary-foreground shadow-sm'
-                        : 'text-foreground/60 hover:bg-accent'
+                        : 'text-foreground/60 hover:text-foreground hover:bg-accent'
                     )}
                   >
-                    <item.icon className="h-4 w-4" />
+                    <item.icon className={cn('h-4 w-4 shrink-0', isActive ? 'text-primary-foreground' : '')} />
                     {item.label}
                   </Link>
                 );
               })}
             </div>
-          ))}
-        </nav>
-      </ScrollArea>
-    </div>
+          </div>
+        ))}
+      </nav>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
- 대시보드 레이아웃을 marketlab과 동일한 구조로 정렬

## Changes
| 요소 | Before | After (marketlab 동일) |
|------|--------|----------------------|
| Sidebar 폭 | `w-60` | `w-[240px]` |
| Sidebar 로고 | 텍스트만 | 로고 + "Real Estate Intelligence" 서브텍스트 |
| 검색 버튼 | 없음 | ⌘K 검색 트리거 (UI만, 기능 추후) |
| 반응형 기준 | `lg:block` | `md:flex` |
| 헤더 배경 | `bg-background/95` | `bg-card/90 backdrop-blur-sm` |
| 헤더 내용 | 빈 공간 | 실시간 날짜·시각 |
| 모바일 사이드바 | `w-72` | `w-64` + `backgroundColor: white` |
| Shell | 기본 flex | `overflow-hidden` + `min-w-0` |

## Test
- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)