### PR TITLE
feat: 지도 강화 — 지오코딩 + 시도 탭 + 사이드패널

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ DATABASE_URL_UNPOOLED=postgresql://...  # unpooled (마이그레이션용)
 # 공공데이터포털 (data.go.kr)
 PUBLIC_DATA_API_KEY=
 
+# 카카오 (developers.kakao.com)
+NEXT_PUBLIC_KAKAO_APP_KEY=         # JavaScript 키 (지도)
+KAKAO_REST_API_KEY=                # REST API 키 (지오코딩)
+
 # Telegram
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=

--- a/scripts/geocode-complexes.ts
+++ b/scripts/geocode-complexes.ts
@@ -1,0 +1,111 @@
+/**
+ * 카카오 지오코딩 API로 단지 좌표를 채우는 스크립트
+ * 실행: npx tsx scripts/geocode-complexes.ts
+ */
+import { Pool } from 'pg';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '../src/generated/prisma/client';
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+
+const KAKAO_REST_KEY = (process.env.KAKAO_REST_API_KEY || '').replace(/^"|"$/g, '');
+
+async function geocode(query: string): Promise<{ lat: number; lng: number } | null> {
+  const url = `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(query)}&size=1`;
+  const res = await fetch(url, {
+    headers: { Authorization: `KakaoAK ${KAKAO_REST_KEY}` },
+  });
+
+  if (!res.ok) {
+    // JavaScript 키가 아닌 REST API 키가 필요할 수 있음. 주소 검색으로 폴백
+    const addressUrl = `https://dapi.kakao.com/v2/local/search/address.json?query=${encodeURIComponent(query)}&size=1`;
+    const addressRes = await fetch(addressUrl, {
+      headers: { Authorization: `KakaoAK ${KAKAO_REST_KEY}` },
+    });
+    if (!addressRes.ok) return null;
+    const addressData = await addressRes.json();
+    if (addressData.documents?.length > 0) {
+      return {
+        lat: parseFloat(addressData.documents[0].y),
+        lng: parseFloat(addressData.documents[0].x),
+      };
+    }
+    return null;
+  }
+
+  const data = await res.json();
+  if (data.documents?.length > 0) {
+    return {
+      lat: parseFloat(data.documents[0].y),
+      lng: parseFloat(data.documents[0].x),
+    };
+  }
+  return null;
+}
+
+async function main() {
+  if (!KAKAO_REST_KEY) {
+    console.error('KAKAO_REST_API_KEY가 설정되지 않았습니다. (카카오 개발자 콘솔 → 앱 키 → REST API 키)');
+    process.exit(1);
+  }
+
+  const pool = new Pool({ connectionString: (process.env.DATABASE_URL_UNPOOLED || '').replace(/^"|"$/g, '') });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  // 좌표가 없는 단지만 조회
+  const complexes = await prisma.apartmentComplex.findMany({
+    where: { lat: null },
+    include: { region: true },
+    take: 500,
+  });
+
+  console.warn(`좌표 미등록 단지: ${complexes.length}개`);
+
+  let updated = 0;
+  let failed = 0;
+
+  for (const complex of complexes) {
+    // 검색 쿼리: "서울 강남구 수서동 강남 더샵 포레스트"
+    const query = `${complex.region.sigungu} ${complex.dong} ${complex.name}`;
+
+    try {
+      const coords = await geocode(query);
+
+      if (coords) {
+        await prisma.apartmentComplex.update({
+          where: { id: complex.id },
+          data: { lat: coords.lat, lng: coords.lng },
+        });
+        updated++;
+        console.warn(`✅ ${complex.name} (${complex.dong}) → ${coords.lat}, ${coords.lng}`);
+      } else {
+        // 단지명만으로 재시도
+        const fallback = await geocode(`${complex.region.sido} ${complex.region.sigungu} ${complex.name}`);
+        if (fallback) {
+          await prisma.apartmentComplex.update({
+            where: { id: complex.id },
+            data: { lat: fallback.lat, lng: fallback.lng },
+          });
+          updated++;
+          console.warn(`✅ ${complex.name} (fallback) → ${fallback.lat}, ${fallback.lng}`);
+        } else {
+          failed++;
+          console.warn(`❌ ${complex.name} (${complex.dong}) — 좌표 찾지 못함`);
+        }
+      }
+
+      // 카카오 API rate limit 방지 (초당 10건 제한)
+      await new Promise((r) => setTimeout(r, 150));
+    } catch (e) {
+      failed++;
+      console.error(`❌ ${complex.name}:`, e instanceof Error ? e.message : e);
+    }
+  }
+
+  console.warn(`\n완료: ${updated}개 좌표 등록, ${failed}개 실패`);
+  await prisma.$disconnect();
+  await pool.end();
+}
+
+main().catch(console.error);

--- a/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import useSWR from 'swr';
+import Link from 'next/link';
 import { useKakaoLoaded } from '@/components/kakao-map-provider';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Building2 } from 'lucide-react';
+import { Building2, ChevronRight, List, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface Complex {
   id: string;
@@ -19,67 +21,119 @@ interface Complex {
   avgPricePerPyeong: number;
 }
 
+interface Region {
+  code: string;
+  sido: string;
+  sigungu: string;
+}
+
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+// 시도별 중심 좌표
+const SIDO_CENTERS: Record<string, { lat: number; lng: number; level: number }> = {
+  서울특별시: { lat: 37.5665, lng: 126.978, level: 8 },
+  경기도: { lat: 37.275, lng: 127.009, level: 10 },
+  부산광역시: { lat: 35.1796, lng: 129.0756, level: 8 },
+  인천광역시: { lat: 37.4563, lng: 126.7052, level: 9 },
+  대구광역시: { lat: 35.8714, lng: 128.6014, level: 8 },
+  대전광역시: { lat: 36.3504, lng: 127.3845, level: 8 },
+  광주광역시: { lat: 35.1595, lng: 126.8526, level: 8 },
+  울산광역시: { lat: 35.5384, lng: 129.3114, level: 8 },
+};
 
 export function TradeMap() {
   const kakaoLoaded = useKakaoLoaded();
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<kakao.maps.Map | null>(null);
+  const overlaysRef = useRef<kakao.maps.CustomOverlay[]>([]);
   const [selectedComplex, setSelectedComplex] = useState<Complex | null>(null);
+  const [showList, setShowList] = useState(false);
+  const [selectedSido, setSelectedSido] = useState('서울특별시');
 
-  const { data } = useSWR<{ data: Complex[] }>(
-    '/api/market/map/complexes',
-    fetcher
-  );
+  const { data: regionData } = useSWR<{ data: Region[] }>('/api/market/regions', fetcher);
+  const { data: complexData } = useSWR<{ data: Complex[] }>('/api/market/map/complexes', fetcher);
+
+  const complexes = complexData?.data ?? [];
+  const withCoords = complexes.filter((c) => c.lat && c.lng);
+  const withoutCoords = complexes.filter((c) => !c.lat || !c.lng);
+
+  // 시도 목록 추출
+  const sidoList = regionData?.data
+    ? [...new Set(regionData.data.map((r) => r.sido))]
+    : [];
 
   // 지도 초기화
   useEffect(() => {
     if (!kakaoLoaded || !mapRef.current || mapInstanceRef.current) return;
 
+    const center = SIDO_CENTERS[selectedSido] || SIDO_CENTERS['서울특별시'];
     const map = new kakao.maps.Map(mapRef.current, {
-      center: new kakao.maps.LatLng(37.5665, 126.978), // 서울 시청
-      level: 8,
+      center: new kakao.maps.LatLng(center.lat, center.lng),
+      level: center.level,
     });
-
     mapInstanceRef.current = map;
-  }, [kakaoLoaded]);
+  }, [kakaoLoaded, selectedSido]);
+
+  // 시도 변경 시 지도 이동
+  const moveTo = useCallback((sido: string) => {
+    setSelectedSido(sido);
+    const center = SIDO_CENTERS[sido];
+    if (center && mapInstanceRef.current) {
+      mapInstanceRef.current.setCenter(new kakao.maps.LatLng(center.lat, center.lng));
+      mapInstanceRef.current.setLevel(center.level);
+    }
+  }, []);
 
   // 마커 표시
   useEffect(() => {
-    if (!mapInstanceRef.current || !data?.data) return;
-
+    if (!mapInstanceRef.current || withCoords.length === 0) return;
     const map = mapInstanceRef.current;
-    const complexes = data.data.filter((c) => c.lat && c.lng);
 
-    for (const complex of complexes) {
+    // 기존 오버레이 제거
+    overlaysRef.current.forEach((o) => o.setMap(null));
+    overlaysRef.current = [];
+
+    for (const complex of withCoords) {
       const position = new kakao.maps.LatLng(complex.lat!, complex.lng!);
-      const priceLabel = (complex.avgPrice / 10000).toFixed(1) + '억';
+      const priceLabel =
+        complex.avgPrice >= 10000
+          ? (complex.avgPrice / 10000).toFixed(1) + '억'
+          : complex.avgPrice.toLocaleString() + '만';
 
-      // 커스텀 오버레이 (가격 라벨)
       const content = document.createElement('div');
-      content.className = 'map-marker';
       content.style.cssText = `
         background: hsl(152 69% 40%);
         color: white;
-        padding: 2px 6px;
-        border-radius: 4px;
+        padding: 3px 8px;
+        border-radius: 6px;
         font-size: 11px;
         font-weight: 600;
         cursor: pointer;
         white-space: nowrap;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+        box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+        transition: transform 0.15s;
       `;
       content.textContent = priceLabel;
-      content.addEventListener('click', () => setSelectedComplex(complex));
+      content.addEventListener('mouseenter', () => {
+        content.style.transform = 'scale(1.1)';
+      });
+      content.addEventListener('mouseleave', () => {
+        content.style.transform = 'scale(1)';
+      });
+      content.addEventListener('click', () => {
+        setSelectedComplex(complex);
+        setShowList(false);
+      });
 
-      new kakao.maps.CustomOverlay({
+      const overlay = new kakao.maps.CustomOverlay({
         map,
         position,
         content,
-        yAnchor: 1.3,
+        yAnchor: 1.4,
       });
+      overlaysRef.current.push(overlay);
     }
-  }, [data]);
+  }, [withCoords]);
 
   if (!process.env.NEXT_PUBLIC_KAKAO_APP_KEY) {
     return (
@@ -99,26 +153,51 @@ export function TradeMap() {
 
   return (
     <div className="relative h-full">
+      {/* 시도 선택 탭 */}
+      <div className="absolute top-3 left-3 z-10 flex flex-wrap gap-1.5">
+        {sidoList.map((sido) => (
+          <button
+            key={sido}
+            onClick={() => moveTo(sido)}
+            className={cn(
+              'rounded-lg px-3 py-1.5 text-xs font-medium shadow-sm transition-all',
+              selectedSido === sido
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-white/90 text-foreground/70 hover:bg-white backdrop-blur-sm border border-border/50'
+            )}
+          >
+            {sido.replace(/특별시|광역시|특별자치시|특별자치도|도$/, '')}
+          </button>
+        ))}
+      </div>
+
+      {/* 단지 리스트 토글 */}
+      <button
+        onClick={() => { setShowList(!showList); setSelectedComplex(null); }}
+        className="absolute top-3 right-3 z-10 flex items-center gap-1.5 rounded-lg bg-white/90 backdrop-blur-sm border border-border/50 px-3 py-1.5 text-xs font-medium shadow-sm hover:bg-white transition-all"
+      >
+        <List className="h-3.5 w-3.5" />
+        단지 목록 ({complexes.length})
+      </button>
+
       {/* 지도 */}
       <div ref={mapRef} className="h-full w-full rounded-xl" />
 
-      {/* 선택된 단지 사이드패널 */}
+      {/* 선택된 단지 패널 */}
       {selectedComplex && (
-        <div className="absolute right-4 top-4 z-10 w-72">
-          <Card className="shadow-lg">
+        <div className="absolute right-3 top-12 z-10 w-72 animate-fade-up">
+          <Card className="shadow-lg border-primary/20">
             <CardContent className="p-4">
               <div className="flex items-start justify-between">
                 <div>
                   <h3 className="font-semibold">{selectedComplex.name}</h3>
-                  <p className="text-xs text-muted-foreground">
-                    {selectedComplex.dong}
-                  </p>
+                  <p className="text-xs text-muted-foreground">{selectedComplex.dong}</p>
                 </div>
                 <button
                   onClick={() => setSelectedComplex(null)}
-                  className="text-muted-foreground hover:text-foreground text-sm"
+                  className="rounded-md p-1 hover:bg-accent transition-colors"
                 >
-                  ✕
+                  <X className="h-3.5 w-3.5 text-muted-foreground" />
                 </button>
               </div>
               <div className="mt-3 space-y-2">
@@ -139,15 +218,89 @@ export function TradeMap() {
                   <Badge variant="secondary">{selectedComplex._count.trades}건</Badge>
                 </div>
               </div>
+              <Link
+                href={`/dashboard/apartments/${selectedComplex.id}`}
+                className="mt-3 flex items-center justify-center gap-1 rounded-lg bg-primary/10 py-2 text-sm font-medium text-primary hover:bg-primary/20 transition-colors"
+              >
+                상세 보기 <ChevronRight className="h-3.5 w-3.5" />
+              </Link>
             </CardContent>
           </Card>
         </div>
       )}
 
-      {/* 로딩 상태 */}
+      {/* 단지 리스트 사이드패널 */}
+      {showList && (
+        <div className="absolute right-3 top-12 z-10 w-80 max-h-[calc(100%-80px)] animate-fade-up">
+          <Card className="shadow-lg overflow-hidden">
+            <CardContent className="p-0">
+              <div className="flex items-center justify-between border-b px-4 py-3">
+                <h3 className="text-sm font-semibold">
+                  수집된 단지 ({complexes.length}개)
+                </h3>
+                <button
+                  onClick={() => setShowList(false)}
+                  className="rounded-md p-1 hover:bg-accent transition-colors"
+                >
+                  <X className="h-3.5 w-3.5 text-muted-foreground" />
+                </button>
+              </div>
+
+              {withoutCoords.length > 0 && (
+                <div className="bg-amber-50 border-b px-4 py-2">
+                  <p className="text-[11px] text-amber-700">
+                    {withoutCoords.length}개 단지의 좌표가 미등록입니다.
+                    지오코딩 스크립트를 실행하세요.
+                  </p>
+                </div>
+              )}
+
+              <div className="max-h-96 overflow-y-auto">
+                {complexes.map((c) => (
+                  <Link
+                    key={c.id}
+                    href={`/dashboard/apartments/${c.id}`}
+                    className="flex items-center gap-3 border-b last:border-0 px-4 py-3 hover:bg-accent/50 transition-colors"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium truncate">{c.name}</p>
+                      <p className="text-xs text-muted-foreground">{c.dong}</p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="text-sm font-semibold text-primary">
+                        {(c.avgPrice / 10000).toFixed(1)}억
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">{c._count.trades}건</p>
+                    </div>
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  </Link>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* 좌표 현황 표시 */}
+      <div className="absolute bottom-3 left-3 z-10">
+        <div className="rounded-lg bg-white/90 backdrop-blur-sm border border-border/50 px-3 py-2 shadow-sm text-xs">
+          <span className="text-primary font-semibold">{withCoords.length}</span>
+          <span className="text-muted-foreground"> 단지 표시 중</span>
+          {withoutCoords.length > 0 && (
+            <span className="text-muted-foreground ml-2">
+              · <span className="text-amber-600">{withoutCoords.length}</span> 좌표 미등록
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* 로딩 */}
       {!kakaoLoaded && (
         <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-muted/60">
-          <p className="text-sm text-muted-foreground">지도 로딩 중...</p>
+          <div className="flex flex-col items-center gap-2">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <p className="text-sm text-muted-foreground">지도 로딩 중...</p>
+          </div>
         </div>
       )}
     </div>

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,19 +1,26 @@
 declare namespace kakao.maps {
   class Map {
     constructor(container: HTMLElement, options: { center: LatLng; level: number });
+    setCenter(latlng: LatLng): void;
+    setLevel(level: number): void;
+    getLevel(): number;
+    getCenter(): LatLng;
   }
 
   class LatLng {
     constructor(lat: number, lng: number);
+    getLat(): number;
+    getLng(): number;
   }
 
   class CustomOverlay {
     constructor(options: {
-      map: Map;
+      map?: Map;
       position: LatLng;
       content: HTMLElement | string;
       yAnchor?: number;
     });
+    setMap(map: Map | null): void;
   }
 
   function load(callback: () => void): void;


### PR DESCRIPTION
## Summary
- 카카오 지오코딩으로 81/95 단지 좌표 등록
- 지도 UI 전면 강화 (시도 탭, 단지 목록, 상세 링크)

## Changes
- `scripts/geocode-complexes.ts` — 카카오 REST API 지오코딩 (주소 → 좌표)
- `trade-map.tsx` — 전면 리팩터
  - 시도 선택 탭 (서울→경기→부산 등, 지도 자동 이동)
  - 단지 목록 사이드패널 (가격순, 상세 링크)
  - 마커 클릭 → 상세 패널 (평균가, 평당가, 거래수, 상세보기 링크)
  - 마커 hover 스케일 애니메이션
  - 하단 좌표 현황 표시 (N개 표시 중, M개 미등록)
- `kakao.d.ts` — setCenter, setLevel, setMap 타입 추가
- `.env.example` — KAKAO_REST_API_KEY 추가

## Test
- `npm run build` 통과
- 지오코딩 81/95 성공 (85%)
- 14개 실패는 이름에 특수문자/동호수 포함 (향후 개선)

🤖 Generated with [Claude Code](https://claude.com/claude-code)