### PR TITLE
fix: 404 페이지 해결 + 지도 에러 처리

### DIFF
--- a/src/app/(dashboard)/dashboard/indices/page.tsx
+++ b/src/app/(dashboard)/dashboard/indices/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { TrendingUp } from 'lucide-react';
+
+export default function IndicesPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">가격지수</h1>
+        <p className="text-muted-foreground">한국부동산원 매매·전세 가격지수로 시장 흐름을 파악합니다.</p>
+      </div>
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-2 py-12">
+          <TrendingUp className="h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-medium">준비 중입니다</p>
+          <p className="text-xs text-muted-foreground">한국부동산원 API 연동 후 가격지수 차트가 표시됩니다.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import useSWR from 'swr';
 import Link from 'next/link';
-import { useKakaoLoaded } from '@/components/kakao-map-provider';
+import { useKakaoLoaded, useKakaoError } from '@/components/kakao-map-provider';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Building2, ChevronRight, List, X } from 'lucide-react';
@@ -43,6 +43,7 @@ const SIDO_CENTERS: Record<string, { lat: number; lng: number; level: number }> 
 
 export function TradeMap() {
   const kakaoLoaded = useKakaoLoaded();
+  const kakaoError = useKakaoError();
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<kakao.maps.Map | null>(null);
   const overlaysRef = useRef<kakao.maps.CustomOverlay[]>([]);
@@ -135,15 +136,19 @@ export function TradeMap() {
     }
   }, [withCoords]);
 
-  if (!process.env.NEXT_PUBLIC_KAKAO_APP_KEY) {
+  if (!process.env.NEXT_PUBLIC_KAKAO_APP_KEY || kakaoError) {
     return (
       <div className="flex h-full items-center justify-center">
         <Card className="border-dashed">
           <CardContent className="flex flex-col items-center gap-2 py-8 px-12">
             <Building2 className="h-8 w-8 text-muted-foreground" />
-            <p className="text-sm font-medium">카카오맵 API 키가 필요합니다</p>
-            <p className="text-xs text-muted-foreground text-center">
-              NEXT_PUBLIC_KAKAO_APP_KEY 환경변수를 설정하세요.
+            <p className="text-sm font-medium">
+              {kakaoError ? '카카오맵 로드에 실패했습니다' : '카카오맵 API 키가 필요합니다'}
+            </p>
+            <p className="text-xs text-muted-foreground text-center max-w-xs">
+              {kakaoError
+                ? '카카오 개발자 콘솔 → 플랫폼 → Web에 도메인을 등록했는지 확인하세요.'
+                : 'NEXT_PUBLIC_KAKAO_APP_KEY 환경변수를 설정하세요.'}
             </p>
           </CardContent>
         </Card>

--- a/src/app/(dashboard)/dashboard/rates/page.tsx
+++ b/src/app/(dashboard)/dashboard/rates/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Landmark } from 'lucide-react';
+
+export default function RatesPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">금리 동향</h1>
+        <p className="text-muted-foreground">기준금리, 주담대, CD금리 등 부동산 관련 금리를 추적합니다.</p>
+      </div>
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-2 py-12">
+          <Landmark className="h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-medium">준비 중입니다</p>
+          <p className="text-xs text-muted-foreground">한국은행 ECOS API 연동 후 금리 차트가 표시됩니다.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/subscriptions/page.tsx
+++ b/src/app/(dashboard)/dashboard/subscriptions/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { CalendarDays } from 'lucide-react';
+
+export default function SubscriptionsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">청약 정보</h1>
+        <p className="text-muted-foreground">분양 일정, 청약 경쟁률, 당첨 정보를 확인합니다.</p>
+      </div>
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-2 py-12">
+          <CalendarDays className="h-8 w-8 text-muted-foreground" />
+          <p className="text-sm font-medium">준비 중입니다</p>
+          <p className="text-xs text-muted-foreground">청약홈 API 연동 후 청약 일정이 표시됩니다.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/kakao-map-provider.tsx
+++ b/src/components/kakao-map-provider.tsx
@@ -3,28 +3,47 @@
 import Script from 'next/script';
 import { useState, createContext, useContext } from 'react';
 
-const KakaoContext = createContext(false);
+interface KakaoContextValue {
+  loaded: boolean;
+  error: boolean;
+}
+
+const KakaoContext = createContext<KakaoContextValue>({ loaded: false, error: false });
 
 export function useKakaoLoaded() {
-  return useContext(KakaoContext);
+  return useContext(KakaoContext).loaded;
+}
+
+export function useKakaoError() {
+  return useContext(KakaoContext).error;
 }
 
 export function KakaoMapProvider({ children }: { children: React.ReactNode }) {
   const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState(false);
   const appKey = process.env.NEXT_PUBLIC_KAKAO_APP_KEY;
 
   if (!appKey) {
-    return <>{children}</>;
+    return (
+      <KakaoContext.Provider value={{ loaded: false, error: true }}>
+        {children}
+      </KakaoContext.Provider>
+    );
   }
 
   return (
-    <KakaoContext.Provider value={loaded}>
+    <KakaoContext.Provider value={{ loaded, error }}>
       <Script
         src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${appKey}&autoload=false&libraries=clusterer`}
         strategy="afterInteractive"
         onLoad={() => {
-          window.kakao.maps.load(() => setLoaded(true));
+          try {
+            window.kakao.maps.load(() => setLoaded(true));
+          } catch {
+            setError(true);
+          }
         }}
+        onError={() => setError(true)}
       />
       {children}
     </KakaoContext.Provider>


### PR DESCRIPTION
## Summary
- 사이드바 메뉴의 404 페이지 3개 해결
- 카카오맵 도메인 미등록 시 에러 안내 UI 추가

## Changes
- `/dashboard/rates` — 금리 동향 (준비 중 UI)
- `/dashboard/indices` — 가격지수 (준비 중 UI)
- `/dashboard/subscriptions` — 청약 정보 (준비 중 UI)
- `kakao-map-provider.tsx` — onError 핸들링 + useKakaoError 훅
- `trade-map.tsx` — 에러 시 도메인 등록 안내 메시지

## 카카오맵 도메인 등록 필요
카카오 개발자 콘솔 → 앱 설정 → 플랫폼 → Web → 사이트 도메인:
- `http://localhost:3000`
- `https://estatelab.vercel.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 대시보드에 가격지수, 금리 동향, 청약 정보 섹션 추가
* 카카오 맵 오류 처리 개선 - API 설정 누락 또는 로딩 실패 시 사용자 친화적인 안내 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->