### PR TITLE
fix: 지도 줌 초기화 버그 수정

### DIFF
--- a/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
@@ -62,6 +62,8 @@ export function TradeMap() {
   const mapInstanceRef = useRef<kakao.maps.Map | null>(null);
   const overlaysRef = useRef<kakao.maps.CustomOverlay[]>([]);
   const clustererRef = useRef<kakao.maps.MarkerClusterer | null>(null);
+  const initialFitDoneRef = useRef(false);
+  const listenersAttachedRef = useRef(false);
   const [selectedComplex, setSelectedComplex] = useState<Complex | null>(null);
   const [showList, setShowList] = useState(false);
   const [selectedSido, setSelectedSido] = useState('서울특별시');
@@ -247,14 +249,20 @@ export function TradeMap() {
     }
 
     updateOverlayVisibility();
-    kakao.maps.event.addListener(map, 'zoom_changed', updateOverlayVisibility);
-    kakao.maps.event.addListener(map, 'bounds_changed', updateOverlayVisibility);
 
-    // 데이터 있는 영역으로 자동 fit
-    if (withCoords.length > 1) {
+    // 이벤트 리스너는 최초 1회만 등록
+    if (!listenersAttachedRef.current) {
+      kakao.maps.event.addListener(map, 'zoom_changed', updateOverlayVisibility);
+      kakao.maps.event.addListener(map, 'bounds_changed', updateOverlayVisibility);
+      listenersAttachedRef.current = true;
+    }
+
+    // 데이터 있는 영역으로 자동 fit (최초 1회만)
+    if (!initialFitDoneRef.current && withCoords.length > 1) {
       const bounds = new kakao.maps.LatLngBounds();
       withCoords.forEach((c) => bounds.extend(new kakao.maps.LatLng(c.lat!, c.lng!)));
       map.setBounds(bounds, 50, 50, 50, 50);
+      initialFitDoneRef.current = true;
     }
   }, [withCoords]);
 


### PR DESCRIPTION
## Summary
지도 확대 후 줌이 자동으로 초기화되는 버그 수정

## Root Cause
SWR이 데이터를 refetch할 때 `withCoords` 배열 참조가 변경 → useEffect 재실행 → `setBounds()` 다시 호출 → 줌 리셋

## Fix
- `initialFitDoneRef`: setBounds를 최초 데이터 로드 시 1회만 실행
- `listenersAttachedRef`: zoom_changed, bounds_changed 리스너 중복 등록 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)