### PR TITLE
fix: 지도 컨트롤에 텍스트 레이블 추가

### DIFF
--- a/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
@@ -376,38 +376,41 @@ export function TradeMap() {
           <button
             onClick={toggleMapType}
             className={cn(
-              'p-2 transition-colors border-b border-border/30 relative',
+              'flex items-center gap-2 px-3 py-2 text-[11px] font-medium transition-colors border-b border-border/30',
               mapType === 'skyview' ? 'bg-primary/10 text-primary' : 'hover:bg-accent'
             )}
-            title={mapType === 'road' ? '스카이뷰' : '일반지도'}
           >
-            {mapType === 'road' ? <Satellite className="h-4 w-4" /> : <MapIcon className="h-4 w-4" />}
+            {mapType === 'road' ? <Satellite className="h-3.5 w-3.5" /> : <MapIcon className="h-3.5 w-3.5" />}
+            {mapType === 'road' ? '위성지도' : '일반지도'}
           </button>
           <button
             onClick={toggleDistrict}
             className={cn(
-              'p-2 transition-colors relative',
+              'flex items-center gap-2 px-3 py-2 text-[11px] font-medium transition-colors',
               showDistrict ? 'bg-primary/10 text-primary' : 'hover:bg-accent'
             )}
-            title="지적편집도"
           >
-            <Layers className="h-4 w-4" />
+            <Layers className="h-3.5 w-3.5" />
+            지적편집도
             {showDistrict && (
-              <span className="absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full bg-primary" />
+              <span className="ml-auto h-1.5 w-1.5 rounded-full bg-primary" />
             )}
           </button>
         </div>
 
         {/* 줌 컨트롤 */}
         <div className="flex flex-col rounded-lg bg-white/95 backdrop-blur-sm border border-border/50 shadow-sm overflow-hidden">
-          <button onClick={handleZoomIn} className="p-2 hover:bg-accent transition-colors border-b border-border/30">
-            <ZoomIn className="h-4 w-4" />
+          <button onClick={handleZoomIn} className="flex items-center gap-2 px-3 py-2 text-[11px] font-medium hover:bg-accent transition-colors border-b border-border/30">
+            <ZoomIn className="h-3.5 w-3.5" />
+            확대
           </button>
-          <button onClick={handleZoomOut} className="p-2 hover:bg-accent transition-colors border-b border-border/30">
-            <ZoomOut className="h-4 w-4" />
+          <button onClick={handleZoomOut} className="flex items-center gap-2 px-3 py-2 text-[11px] font-medium hover:bg-accent transition-colors border-b border-border/30">
+            <ZoomOut className="h-3.5 w-3.5" />
+            축소
           </button>
-          <button onClick={handleFitBounds} className="p-2 hover:bg-accent transition-colors" title="전체 보기">
-            <Locate className="h-4 w-4" />
+          <button onClick={handleFitBounds} className="flex items-center gap-2 px-3 py-2 text-[11px] font-medium hover:bg-accent transition-colors">
+            <Locate className="h-3.5 w-3.5" />
+            전체 보기
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
우측 컨트롤 버튼에 아이콘 + 텍스트 레이블 추가

## Before → After
```
[🛰️]              → [🛰️ 위성지도  ]
[📐]              → [📐 지적편집도 ●]
[+]               → [🔍 확대      ]
[-]               → [🔍 축소      ]
[◎]               → [◎  전체 보기  ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)