### PR TITLE
feat: 수집 시 자동 지오코딩

### DIFF
--- a/scripts/bulk-collect.ts
+++ b/scripts/bulk-collect.ts
@@ -1,0 +1,203 @@
+/**
+ * 대량 실거래가 수집 스크립트
+ * 실행: npx tsx scripts/bulk-collect.ts
+ * 옵션: --months 6 (기본 6개월)
+ *       --regions seoul (서울만) | all (전국 주요)
+ */
+import { Pool } from 'pg';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '../src/generated/prisma/client';
+import { fetchApartmentTrades, buildRoadAddress, buildJibunAddress } from '../src/lib/public-data';
+import { geocodeComplex } from '../src/lib/geocode';
+import { config } from 'dotenv';
+config({ path: '.env.local' });
+
+const SEOUL_CODES = [
+  '11110', '11140', '11170', '11200', '11215', '11230', '11260', '11290',
+  '11305', '11320', '11350', '11380', '11410', '11440', '11470', '11500',
+  '11530', '11545', '11560', '11590', '11620', '11650', '11680', '11710', '11740',
+];
+
+const MAJOR_CODES = [
+  ...SEOUL_CODES,
+  // 경기 주요
+  '41117', '41135', '41173', '41190', '41285', '41465', '41570',
+  // 부산 주요
+  '26350', '26260',
+  // 인천 주요
+  '28185', '28260',
+];
+
+function getRecentMonths(count: number): string[] {
+  const months: string[] = [];
+  const now = new Date();
+  for (let i = 1; i <= count; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const ym = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}`;
+    months.push(ym);
+  }
+  return months;
+}
+
+async function main() {
+  const monthCount = parseInt(process.argv.find(a => a.startsWith('--months='))?.split('=')[1] || '6', 10);
+  const regionArg = process.argv.find(a => a.startsWith('--regions='))?.split('=')[1] || 'seoul';
+  const codes = regionArg === 'all' ? MAJOR_CODES : SEOUL_CODES;
+  const months = getRecentMonths(monthCount);
+
+  const pool = new Pool({
+    connectionString: (process.env.DATABASE_URL_UNPOOLED || '').replace(/^"|"$/g, ''),
+  });
+  const adapter = new PrismaPg(pool);
+  const prisma = new PrismaClient({ adapter });
+
+  const totalJobs = codes.length * months.length;
+  console.warn(`수집 대상: ${codes.length}개 지역 × ${months.length}개월 = ${totalJobs}건`);
+  console.warn(`지역: ${regionArg} | 기간: ${months[months.length - 1]} ~ ${months[0]}`);
+
+  let totalCollected = 0;
+  let totalSkipped = 0;
+  let jobsDone = 0;
+
+  for (const lawdCd of codes) {
+    for (const dealYmd of months) {
+      jobsDone++;
+      const prefix = `[${jobsDone}/${totalJobs}] ${lawdCd} ${dealYmd}`;
+
+      try {
+        const rawTrades = await fetchApartmentTrades(lawdCd, dealYmd);
+
+        if (rawTrades.length === 0) {
+          console.warn(`${prefix} — 0건 (스킵)`);
+          continue;
+        }
+
+        let created = 0;
+        let skipped = 0;
+
+        // 지역 정보 (지오코딩용)
+        const region = await prisma.region.findUnique({ where: { code: lawdCd } });
+
+        for (const trade of rawTrades) {
+          try {
+            const dong = trade.dong || '';
+            const jibun = trade.jibun || buildJibunAddress(trade.bonbun, trade.bubun) || '';
+            const roadAddress = buildRoadAddress(trade.roadName, trade.roadBonbun, trade.roadBubun);
+
+            // 기존 단지 확인
+            let complex = await prisma.apartmentComplex.findUnique({
+              where: {
+                regionCode_name_dong_jibun: {
+                  regionCode: lawdCd,
+                  name: trade.aptName,
+                  dong,
+                  jibun,
+                },
+              },
+            });
+
+            if (complex) {
+              complex = await prisma.apartmentComplex.update({
+                where: { id: complex.id },
+                data: {
+                  builtYear: trade.buildYear || undefined,
+                  roadAddress: roadAddress || undefined,
+                },
+              });
+            } else {
+              // 새 단지 — 지오코딩 시도
+              let lat: number | null = null;
+              let lng: number | null = null;
+
+              if (region) {
+                try {
+                  const coords = await geocodeComplex({
+                    name: trade.aptName,
+                    dong,
+                    jibun,
+                    sido: region.sido,
+                    sigungu: region.sigungu,
+                    roadAddress,
+                  });
+                  if (coords) { lat = coords.lat; lng = coords.lng; }
+                } catch {
+                  // 지오코딩 실패 — 무시
+                }
+              }
+
+              complex = await prisma.apartmentComplex.create({
+                data: {
+                  regionCode: lawdCd,
+                  name: trade.aptName,
+                  dong,
+                  jibun,
+                  builtYear: trade.buildYear || null,
+                  roadAddress,
+                  lat,
+                  lng,
+                },
+              });
+            }
+
+            const dealDate = new Date(trade.dealYear, trade.dealMonth - 1, trade.dealDay);
+            const pyeong = trade.area / 3.3058;
+            const pricePerPyeong = Math.round(trade.price / pyeong);
+
+            await prisma.apartmentTrade.upsert({
+              where: {
+                complexId_dealDate_area_floor_price: {
+                  complexId: complex.id,
+                  dealDate,
+                  area: trade.area,
+                  floor: trade.floor,
+                  price: trade.price,
+                },
+              },
+              update: {
+                dealType: trade.dealType,
+                canceledAt: trade.canceledAt,
+                registeredAt: trade.registeredAt,
+                pricePerPyeong,
+              },
+              create: {
+                complexId: complex.id,
+                dealYear: trade.dealYear,
+                dealMonth: trade.dealMonth,
+                dealDay: trade.dealDay,
+                dealDate,
+                area: trade.area,
+                floor: trade.floor,
+                price: trade.price,
+                pricePerPyeong,
+                dealType: trade.dealType,
+                canceledAt: trade.canceledAt,
+                registeredAt: trade.registeredAt,
+              },
+            });
+            created++;
+          } catch {
+            skipped++;
+          }
+        }
+
+        totalCollected += created;
+        totalSkipped += skipped;
+        console.warn(`${prefix} — ${created}건 수집 (${skipped}건 스킵)`);
+
+        // API rate limit 방지 (1초 대기)
+        await new Promise((r) => setTimeout(r, 1000));
+      } catch (e) {
+        console.error(`${prefix} — 오류:`, e instanceof Error ? e.message : e);
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    }
+  }
+
+  console.warn(`\n=== 완료 ===`);
+  console.warn(`총 수집: ${totalCollected}건, 스킵: ${totalSkipped}건`);
+
+  await prisma.$disconnect();
+  await pool.end();
+}
+
+main().catch(console.error);

--- a/src/app/api/collect/trades/route.ts
+++ b/src/app/api/collect/trades/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { fetchApartmentTrades, buildRoadAddress, buildJibunAddress } from '@/lib/public-data';
+import { geocodeComplex } from '@/lib/geocode';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -48,14 +49,17 @@ export async function POST(request: NextRequest) {
     let created = 0;
     let skipped = 0;
 
+    // 지역 정보 조회 (지오코딩에 필요)
+    const region = await prisma.region.findUnique({ where: { code: lawdCd } });
+
     for (const trade of rawTrades) {
       try {
-        // 단지 upsert
         const dong = trade.dong || '';
         const jibun = trade.jibun || buildJibunAddress(trade.bonbun, trade.bubun) || '';
         const roadAddress = buildRoadAddress(trade.roadName, trade.roadBonbun, trade.roadBubun);
 
-        const complex = await prisma.apartmentComplex.upsert({
+        // 기존 단지 확인
+        let complex = await prisma.apartmentComplex.findUnique({
           where: {
             regionCode_name_dong_jibun: {
               regionCode: lawdCd,
@@ -64,19 +68,54 @@ export async function POST(request: NextRequest) {
               jibun,
             },
           },
-          update: {
-            builtYear: trade.buildYear || undefined,
-            roadAddress: roadAddress || undefined,
-          },
-          create: {
-            regionCode: lawdCd,
-            name: trade.aptName,
-            dong,
-            jibun,
-            builtYear: trade.buildYear || null,
-            roadAddress,
-          },
         });
+
+        if (complex) {
+          // 기존 단지 — 정보 업데이트만 (지오코딩 스킵)
+          complex = await prisma.apartmentComplex.update({
+            where: { id: complex.id },
+            data: {
+              builtYear: trade.buildYear || undefined,
+              roadAddress: roadAddress || undefined,
+            },
+          });
+        } else {
+          // 새 단지 — 지오코딩 시도 (실패해도 단지는 생성)
+          let lat: number | null = null;
+          let lng: number | null = null;
+
+          if (region) {
+            try {
+              const coords = await geocodeComplex({
+                name: trade.aptName,
+                dong,
+                jibun,
+                sido: region.sido,
+                sigungu: region.sigungu,
+                roadAddress,
+              });
+              if (coords) {
+                lat = coords.lat;
+                lng = coords.lng;
+              }
+            } catch {
+              // 지오코딩 실패 — 무시, 좌표 없이 생성
+            }
+          }
+
+          complex = await prisma.apartmentComplex.create({
+            data: {
+              regionCode: lawdCd,
+              name: trade.aptName,
+              dong,
+              jibun,
+              builtYear: trade.buildYear || null,
+              roadAddress,
+              lat,
+              lng,
+            },
+          });
+        }
 
         // 거래 데이터 upsert
         const dealDate = new Date(

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -1,0 +1,107 @@
+/**
+ * 카카오 주소 검색 기반 지오코딩
+ * - 수집 API에서 단지 생성 시 자동 호출
+ * - 실패해도 수집은 중단하지 않음 (좌표만 null)
+ */
+
+const KAKAO_REST_KEY = () => (process.env.KAKAO_REST_API_KEY || '').replace(/^"|"$/g, '');
+
+interface GeoResult {
+  lat: number;
+  lng: number;
+  method: string;
+}
+
+async function searchAddress(address: string): Promise<GeoResult | null> {
+  const key = KAKAO_REST_KEY();
+  if (!key) return null;
+
+  try {
+    const url = `https://dapi.kakao.com/v2/local/search/address.json?query=${encodeURIComponent(address)}&size=1`;
+    const res = await fetch(url, {
+      headers: { Authorization: `KakaoAK ${key}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data.documents?.length > 0) {
+      return {
+        lat: parseFloat(data.documents[0].y),
+        lng: parseFloat(data.documents[0].x),
+        method: 'address',
+      };
+    }
+  } catch {
+    // 타임아웃, 네트워크 오류 등 — 무시
+  }
+  return null;
+}
+
+async function searchKeyword(query: string): Promise<GeoResult | null> {
+  const key = KAKAO_REST_KEY();
+  if (!key) return null;
+
+  try {
+    const url = `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(query)}&size=1`;
+    const res = await fetch(url, {
+      headers: { Authorization: `KakaoAK ${key}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (data.documents?.length > 0) {
+      return {
+        lat: parseFloat(data.documents[0].y),
+        lng: parseFloat(data.documents[0].x),
+        method: 'keyword',
+      };
+    }
+  } catch {
+    // 무시
+  }
+  return null;
+}
+
+/**
+ * 단지의 좌표를 찾습니다.
+ * 실패 시 null을 반환합니다 (수집 중단하지 않음).
+ */
+export async function geocodeComplex(params: {
+  name: string;
+  dong: string;
+  jibun: string;
+  sido: string;
+  sigungu: string;
+  roadAddress: string | null;
+}): Promise<{ lat: number; lng: number } | null> {
+  const { name, dong, sido, sigungu, roadAddress } = params;
+
+  try {
+    // 1순위: 도로명주소
+    if (roadAddress && roadAddress.includes(' ')) {
+      const result = await searchAddress(`${sido} ${sigungu} ${roadAddress}`);
+      if (result) return result;
+    }
+
+    // 2순위: 지번주소
+    if (dong && params.jibun) {
+      const result = await searchAddress(`${sido} ${sigungu} ${dong} ${params.jibun}`);
+      if (result) return result;
+    }
+
+    // 3순위: 키워드 검색
+    const aptName = name.includes('아파트') ? name : `${name}아파트`;
+    if (dong) {
+      const result = await searchKeyword(`${sido} ${sigungu} ${dong} ${aptName}`);
+      if (result) return result;
+    }
+
+    // 4순위: 시군구 + 단지명
+    const result = await searchKeyword(`${sigungu} ${aptName}`);
+    if (result) return result;
+  } catch {
+    // 전체 실패 — null 반환, 수집 중단하지 않음
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
실거래가 수집 시 새 단지를 만들면 자동으로 좌표를 채움. 별도 지오코딩 스크립트 실행 불필요.

## 흐름
```
수집 API 호출
  → 거래 데이터 파싱
  → 단지 존재? → YES → update (지오코딩 스킵)
               → NO  → 카카오 지오코딩 → create (좌표 포함)
  → 거래 upsert
```

## 예외처리
- 카카오 API 키 없음 → 좌표 없이 생성
- 지오코딩 타임아웃 (5초) → 좌표 없이 생성
- 네트워크 오류 → 좌표 없이 생성
- **수집은 절대 중단되지 않음**

## Changes
- `src/lib/geocode.ts` — 지오코딩 유틸 (주소검색 → 키워드 폴백, 5초 타임아웃)
- `src/app/api/collect/trades/route.ts` — upsert → findUnique + create/update 분리
- `scripts/bulk-collect.ts` — 동일 로직 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 지역별, 월별로 아파트 거래 데이터를 대량 수집할 수 있는 기능 추가
* 아파트 단지의 정확한 위치 좌표를 자동으로 조회하는 지오코딩 기능 추가

## 개선 사항
* 아파트 단지 정보 저장 시 중복 검사 로직 강화로 데이터 정확도 향상
* 거래 정보 업데이트 프로세스 개선으로 데이터 관리 효율성 증대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->