### PR TITLE
feat: [Epic 6] ECOS 금리 연동

### DIFF
--- a/src/app/(dashboard)/dashboard/rates/page.tsx
+++ b/src/app/(dashboard)/dashboard/rates/page.tsx
@@ -1,20 +1,170 @@
-import { Card, CardContent } from '@/components/ui/card';
-import { Landmark } from 'lucide-react';
+'use client';
+
+import useSWR from 'swr';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Landmark, TrendingDown, TrendingUp, Minus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Rate {
+  name: string;
+  nameKr: string;
+  date: string;
+  rate: number;
+  change: number;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+function RateIcon({ change }: { change: number }) {
+  if (change > 0) return <TrendingUp className="h-4 w-4 text-price-up" />;
+  if (change < 0) return <TrendingDown className="h-4 w-4 text-price-down" />;
+  return <Minus className="h-4 w-4 text-muted-foreground" />;
+}
 
 export default function RatesPage() {
+  const { data: latestData, isLoading: latestLoading } = useSWR<{ data: Rate[] }>(
+    '/api/market/rates',
+    fetcher
+  );
+  const { data: historyData, isLoading: historyLoading } = useSWR<{ data: Rate[] }>(
+    '/api/market/rates/history',
+    fetcher
+  );
+
+  const latest = latestData?.data ?? [];
+  const history = historyData?.data ?? [];
+
+  // 지표별 히스토리 그룹핑
+  const historyByName = new Map<string, Rate[]>();
+  for (const r of history) {
+    const arr = historyByName.get(r.name) || [];
+    arr.push(r);
+    historyByName.set(r.name, arr);
+  }
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">금리 동향</h1>
-        <p className="text-muted-foreground">기준금리, 주담대, CD금리 등 부동산 관련 금리를 추적합니다.</p>
+        <p className="text-muted-foreground">
+          기준금리, 주담대, CD금리 등 부동산 관련 금리를 추적합니다.
+        </p>
       </div>
-      <Card className="border-dashed">
-        <CardContent className="flex flex-col items-center gap-2 py-12">
-          <Landmark className="h-8 w-8 text-muted-foreground" />
-          <p className="text-sm font-medium">준비 중입니다</p>
-          <p className="text-xs text-muted-foreground">한국은행 ECOS API 연동 후 금리 차트가 표시됩니다.</p>
-        </CardContent>
-      </Card>
+
+      {/* 현재 금리 카드 */}
+      {latestLoading ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-28 animate-pulse rounded-xl bg-muted/60" />
+          ))}
+        </div>
+      ) : latest.length === 0 ? (
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center gap-2 py-12">
+            <Landmark className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm font-medium">금리 데이터가 없습니다</p>
+            <p className="text-xs text-muted-foreground">
+              /api/collect/rates 를 호출하여 ECOS 데이터를 수집하세요.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {latest.map((rate, idx) => (
+            <Card key={rate.name} className={`hover-lift animate-fade-up delay-${idx + 1}`}>
+              <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  {rate.nameKr}
+                </CardTitle>
+                <RateIcon change={rate.change} />
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-2xl font-bold">{rate.rate.toFixed(2)}%</span>
+                  {rate.change !== 0 && (
+                    <Badge
+                      variant="secondary"
+                      className={cn(
+                        'text-[10px]',
+                        rate.change > 0 ? 'text-price-up' : 'text-price-down'
+                      )}
+                    >
+                      {rate.change > 0 ? '+' : ''}{rate.change}bp
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {rate.date.slice(0, 10)}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* 금리 추이 차트 */}
+      {!historyLoading && historyByName.size > 0 && (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {Array.from(historyByName.entries()).map(([name, rates]) => {
+            const sorted = rates.sort((a, b) => a.date.localeCompare(b.date));
+            const maxRate = Math.max(...sorted.map((r) => r.rate));
+            const minRate = Math.min(...sorted.map((r) => r.rate));
+            const range = maxRate - minRate || 0.1;
+            const nameKr = sorted[0]?.nameKr || name;
+            const latestRate = sorted[sorted.length - 1];
+
+            return (
+              <Card key={name}>
+                <CardHeader className="pb-3">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-base">{nameKr}</CardTitle>
+                    {latestRate && (
+                      <span className="text-lg font-bold text-primary">
+                        {latestRate.rate.toFixed(2)}%
+                      </span>
+                    )}
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-end gap-[2px] h-32">
+                    {sorted.map((r, idx) => {
+                      const height = ((r.rate - minRate) / range) * 80 + 20;
+                      const isLast = idx === sorted.length - 1;
+                      const month = r.date.slice(5, 7);
+
+                      return (
+                        <div key={r.date} className="flex flex-1 flex-col items-center gap-0.5">
+                          {isLast && (
+                            <span className="text-[9px] font-semibold text-primary">
+                              {r.rate.toFixed(1)}
+                            </span>
+                          )}
+                          <div
+                            className={cn(
+                              'w-full rounded-t transition-all min-h-[4px]',
+                              isLast ? 'bg-primary' : 'bg-primary/20'
+                            )}
+                            style={{ height: `${height}%` }}
+                          />
+                          {(idx === 0 || idx === sorted.length - 1 || idx % 6 === 0) && (
+                            <span className="text-[8px] text-muted-foreground">{month}월</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                  <div className="flex justify-between mt-2 text-[10px] text-muted-foreground">
+                    <span>{sorted[0]?.date.slice(0, 7)}</span>
+                    <span>최저 {minRate.toFixed(2)}% · 최고 {maxRate.toFixed(2)}%</span>
+                    <span>{sorted[sorted.length - 1]?.date.slice(0, 7)}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/api/collect/rates/route.ts
+++ b/src/app/api/collect/rates/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { fetchRates } from '@/lib/ecos';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/collect/rates?months=24
+ * ECOS 금리 데이터를 수집합니다.
+ */
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = (process.env.CRON_SECRET || '').replace(/^"|"$/g, '');
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const months = parseInt(request.nextUrl.searchParams.get('months') || '24', 10);
+  const startTime = Date.now();
+
+  try {
+    const rates = await fetchRates(months);
+
+    let created = 0;
+    let skipped = 0;
+
+    for (const rate of rates) {
+      try {
+        // 이전 데이터 조회 (변동폭 계산)
+        const prev = await prisma.interestRate.findFirst({
+          where: { name: rate.name, date: { lt: rate.date } },
+          orderBy: { date: 'desc' },
+        });
+        const change = prev ? Math.round((rate.rate - prev.rate) * 100) : 0; // bp
+
+        await prisma.interestRate.upsert({
+          where: {
+            name_date: { name: rate.name, date: rate.date },
+          },
+          update: { rate: rate.rate, nameKr: rate.nameKr, change },
+          create: {
+            name: rate.name,
+            nameKr: rate.nameKr,
+            date: rate.date,
+            rate: rate.rate,
+            change,
+          },
+        });
+        created++;
+      } catch {
+        skipped++;
+      }
+    }
+
+    const duration = Date.now() - startTime;
+
+    await prisma.cronExecutionLog.create({
+      data: {
+        endpoint: '/api/collect/rates',
+        status: skipped > 0 ? 'partial' : 'success',
+        duration,
+        recordCount: created,
+        errorCount: skipped,
+      },
+    });
+
+    return NextResponse.json({
+      data: { total: rates.length, collected: created, skipped, duration: `${duration}ms` },
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/market/rates/history/route.ts
+++ b/src/app/api/market/rates/history/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/rates/history
+ * 전체 금리 히스토리 데이터를 조회합니다.
+ */
+export async function GET() {
+  const rates = await prisma.interestRate.findMany({
+    orderBy: { date: 'asc' },
+  });
+
+  return NextResponse.json({ data: rates });
+}

--- a/src/lib/ecos.ts
+++ b/src/lib/ecos.ts
@@ -1,0 +1,156 @@
+/**
+ * 한국은행 ECOS API 클라이언트
+ * https://ecos.bok.or.kr/api/
+ */
+
+const ECOS_BASE = 'https://ecos.bok.or.kr/api/StatisticSearch';
+
+interface EcosRow {
+  STAT_CODE: string;
+  ITEM_NAME1: string;
+  TIME: string;
+  DATA_VALUE: string;
+  UNIT_NAME: string;
+}
+
+interface RateData {
+  name: string;
+  nameKr: string;
+  date: Date;
+  rate: number;
+}
+
+// 수집할 금리 지표 정의
+const RATE_INDICATORS = [
+  {
+    name: 'BASE_RATE',
+    nameKr: '기준금리',
+    statCode: '722Y001',
+    itemCode: '0101000',
+    cycle: 'M',
+  },
+  {
+    name: 'CD_91D',
+    nameKr: 'CD금리(91일)',
+    statCode: '817Y002',
+    itemCode: '010502000',
+    cycle: 'D', // 일간 데이터만 제공
+  },
+  {
+    name: 'TREASURY_3Y',
+    nameKr: '국고채(3년)',
+    statCode: '817Y002',
+    itemCode: '010200000',
+    cycle: 'D', // 일간 데이터만 제공
+  },
+  {
+    name: 'MORTGAGE',
+    nameKr: '주담대',
+    statCode: '121Y006',
+    itemCode: 'BECBLA0302',
+    cycle: 'M',
+  },
+];
+
+async function fetchEcosStat(
+  statCode: string,
+  itemCode: string,
+  cycle: string,
+  startDate: string,
+  endDate: string
+): Promise<EcosRow[]> {
+  const apiKey = (process.env.ECOS_API_KEY || '').replace(/^"|"$/g, '');
+  if (!apiKey) throw new Error('ECOS_API_KEY 환경변수가 설정되지 않았습니다.');
+
+  const url = `${ECOS_BASE}/${apiKey}/json/kr/1/100/${statCode}/${cycle}/${startDate}/${endDate}/${itemCode}`;
+
+  const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+  if (!res.ok) throw new Error(`ECOS API 요청 실패: ${res.status}`);
+
+  const data = await res.json();
+
+  if (data.StatisticSearch?.row) {
+    return data.StatisticSearch.row;
+  }
+
+  // 에러 응답 처리
+  if (data.RESULT?.CODE) {
+    throw new Error(`ECOS: ${data.RESULT.CODE} ${data.RESULT.MESSAGE}`);
+  }
+
+  return [];
+}
+
+function parseTime(time: string): Date {
+  // "202501" → 2025-01-01, "20250115" → 2025-01-15
+  if (time.length === 6) {
+    return new Date(parseInt(time.slice(0, 4), 10), parseInt(time.slice(4, 6), 10) - 1, 1);
+  }
+  return new Date(
+    parseInt(time.slice(0, 4), 10),
+    parseInt(time.slice(4, 6), 10) - 1,
+    parseInt(time.slice(6, 8), 10) || 1
+  );
+}
+
+/** 일간 데이터에서 각 월의 마지막 값만 추출 */
+function filterMonthlyLast(rows: EcosRow[]): EcosRow[] {
+  const monthMap = new Map<string, EcosRow>();
+  for (const row of rows) {
+    const ym = row.TIME.slice(0, 6); // YYYYMM
+    monthMap.set(ym, row); // 마지막 값이 덮어씀
+  }
+  return Array.from(monthMap.values());
+}
+
+/**
+ * 최근 N개월간의 금리 데이터를 수집합니다.
+ */
+export async function fetchRates(months: number = 24): Promise<RateData[]> {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth() - months, 1);
+
+  const monthStart = `${start.getFullYear()}${String(start.getMonth() + 1).padStart(2, '0')}`;
+  const monthEnd = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const dayStart = `${start.getFullYear()}${String(start.getMonth() + 1).padStart(2, '0')}01`;
+  const dayEnd = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
+
+  const results: RateData[] = [];
+
+  for (const indicator of RATE_INDICATORS) {
+    try {
+      const startStr = indicator.cycle === 'D' ? dayStart : monthStart;
+      const endStr = indicator.cycle === 'D' ? dayEnd : monthEnd;
+
+      const rows = await fetchEcosStat(
+        indicator.statCode,
+        indicator.itemCode,
+        indicator.cycle,
+        startStr,
+        endStr
+      );
+
+      // 일간 데이터는 월말 값만 추출 (너무 많으므로)
+      const filtered = indicator.cycle === 'D'
+        ? filterMonthlyLast(rows)
+        : rows;
+
+      for (const row of filtered) {
+        const value = parseFloat(row.DATA_VALUE);
+        if (isNaN(value)) continue;
+
+        results.push({
+          name: indicator.name,
+          nameKr: indicator.nameKr,
+          date: parseTime(row.TIME),
+          rate: value,
+        });
+      }
+    } catch (e) {
+      console.error(`ECOS ${indicator.name} 수집 실패:`, e instanceof Error ? e.message : e);
+      // 개별 지표 실패 시 다른 지표는 계속 수집
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
한국은행 ECOS API 연동 — 4개 금리 지표 수집 + 금리 동향 페이지

## 수집 지표

| 지표 | 최신값 | 출처 |
|------|--------|------|
| 기준금리 | 2.50% | 722Y001 (월간) |
| CD금리(91일) | 3.50% | 817Y002 (일간→월말) |
| 국고채(3년) | 3.02% | 817Y002 (일간→월말) |
| 주담대 | 4.32% | 121Y006 (월간) |

## 금리 동향 페이지
- 현재 금리 4칸 카드 (값 + 변동폭 bp + 방향 아이콘)
- 지표별 추이 바 차트 (24개월)
- 최저/최고 범위 표시

## Changes
- `src/lib/ecos.ts` — ECOS API 클라이언트
- `POST /api/collect/rates` — 금리 수집
- `GET /api/market/rates/history` — 히스토리 조회
- `/dashboard/rates` — 금리 동향 페이지 (준비중 → 실데이터)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)