### PR TITLE
feat: 모바일 반응형 개선 — 지도 하단 시트

### DIFF
--- a/src/app/(dashboard)/dashboard/map/_components/complex-detail-panel.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/complex-detail-panel.tsx
@@ -95,7 +95,7 @@ export function ComplexDetailPanel({ complexId, onClose }: Props) {
   const chartRange = chartMax - chartMin || 1;
 
   return (
-    <div className="absolute left-0 top-0 bottom-0 z-20 w-[380px] bg-white border-r border-border/50 shadow-xl flex flex-col animate-fade-up overflow-hidden">
+    <div className="md:absolute md:left-0 md:top-0 md:bottom-0 z-20 md:w-[380px] w-full bg-white md:border-r border-border/50 md:shadow-xl flex flex-col overflow-hidden">
       {/* 헤더 */}
       {isLoading ? (
         <div className="p-4 space-y-3">

--- a/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
@@ -361,7 +361,7 @@ export function TradeMap() {
   return (
     <div className="relative h-full">
       {/* 시도 선택 탭 */}
-      <div className="absolute top-3 left-3 z-10 flex flex-wrap gap-1.5 max-w-[calc(100%-140px)]">
+      <div className="absolute top-3 left-3 z-10 flex gap-1.5 max-w-[calc(100%-100px)] md:max-w-[calc(100%-140px)] overflow-x-auto scrollbar-none md:flex-wrap">
         {sidoList.map((sido) => (
           <button
             key={sido}
@@ -439,16 +439,34 @@ export function TradeMap() {
       {/* 지도 */}
       <div
         ref={mapRef}
-        className={cn('h-full w-full rounded-xl transition-all', selectedComplex && 'ml-[380px]')}
-        style={selectedComplex ? { width: 'calc(100% - 380px)' } : undefined}
+        className={cn(
+          'h-full w-full rounded-xl transition-all',
+          selectedComplex && 'md:ml-[380px]'
+        )}
+        style={selectedComplex ? { width: undefined } : undefined}
       />
 
-      {/* 좌측 상세 패널 */}
+      {/* 상세 패널 — 데스크톱: 좌측, 모바일: 하단 시트 */}
       {selectedComplex && (
-        <ComplexDetailPanel
-          complexId={selectedComplex.id}
-          onClose={() => setSelectedComplex(null)}
-        />
+        <>
+          {/* 데스크톱 */}
+          <div className="hidden md:block">
+            <ComplexDetailPanel
+              complexId={selectedComplex.id}
+              onClose={() => setSelectedComplex(null)}
+            />
+          </div>
+          {/* 모바일 — 하단 시트 */}
+          <div className="md:hidden absolute bottom-0 left-0 right-0 z-20 max-h-[60vh] overflow-y-auto bg-white rounded-t-2xl shadow-[0_-4px_20px_rgba(0,0,0,0.15)] animate-fade-up">
+            <div className="sticky top-0 flex items-center justify-center py-2 bg-white rounded-t-2xl">
+              <div className="w-10 h-1 rounded-full bg-border" />
+            </div>
+            <ComplexDetailPanel
+              complexId={selectedComplex.id}
+              onClose={() => setSelectedComplex(null)}
+            />
+          </div>
+        </>
       )}
 
       {/* 단지 리스트 사이드패널 */}

--- a/src/app/(dashboard)/dashboard/map/page.tsx
+++ b/src/app/(dashboard)/dashboard/map/page.tsx
@@ -3,8 +3,8 @@ import { TradeMap } from './_components/trade-map';
 
 export default function MapPage() {
   return (
-    <div className="flex h-[calc(100vh-56px-48px)] flex-col gap-4">
-      <div>
+    <div className="flex h-[calc(100vh-56px-32px)] md:h-[calc(100vh-56px-48px)] flex-col gap-2 md:gap-4">
+      <div className="hidden md:block">
         <h1 className="text-2xl font-bold tracking-tight">지도 탐색</h1>
         <p className="text-muted-foreground">지역별 아파트 실거래가를 지도에서 확인하세요.</p>
       </div>


### PR DESCRIPTION
## Summary
모바일에서 지도 사용성 대폭 개선

## Before → After
- 상세 패널: 380px 좌측 고정 (모바일에서 지도 가림) → 모바일: 하단 시트 (60vh)
- 지도 헤더: 항상 표시 → 모바일: 숨김 (지도 영역 최대화)
- 시도 탭: flex-wrap (줄바꿈) → 모바일: 가로 스크롤

🤖 Generated with [Claude Code](https://claude.com/claude-code)