### PR TITLE
feat: ⌘K 커맨드 팔레트 — 단지 검색 + 메뉴

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.27",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "dotenv": "^17.3.1",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
@@ -5178,6 +5179,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "autoprefixer": "^10.4.27",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "dotenv": "^17.3.1",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",

--- a/src/app/(dashboard)/_components/dashboard-shell.tsx
+++ b/src/app/(dashboard)/_components/dashboard-shell.tsx
@@ -1,18 +1,31 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Sidebar } from '@/components/sidebar';
 import { Header } from '@/components/header';
 import { MobileSidebar } from '@/components/mobile-sidebar';
+import { CommandPalette } from '@/components/command-palette';
 
 export function DashboardShell({ children }: { children: React.ReactNode }) {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [cmdOpen, setCmdOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setCmdOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   return (
     <div className="flex h-screen overflow-hidden">
       {/* Desktop sidebar */}
       <div className="hidden md:flex shrink-0">
-        <Sidebar />
+        <Sidebar onCommandOpen={() => setCmdOpen(true)} />
       </div>
 
       {/* Mobile sidebar */}
@@ -25,6 +38,9 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           {children}
         </main>
       </div>
+
+      {/* Command Palette */}
+      <CommandPalette open={cmdOpen} onOpenChange={setCmdOpen} />
     </div>
   );
 }

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { Command } from 'cmdk';
+import {
+  LayoutDashboard,
+  Map,
+  Building2,
+  Landmark,
+  TrendingUp,
+  CalendarDays,
+  Search,
+} from 'lucide-react';
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface SearchResult {
+  id: string;
+  name: string;
+  dong: string;
+  regionCode: string;
+}
+
+const MENU_ITEMS = [
+  { label: '시장 개요', href: '/dashboard', icon: LayoutDashboard },
+  { label: '지도 탐색', href: '/dashboard/map', icon: Map },
+  { label: '아파트', href: '/dashboard/apartments', icon: Building2 },
+  { label: '금리 동향', href: '/dashboard/rates', icon: Landmark },
+  { label: '가격지수', href: '/dashboard/indices', icon: TrendingUp },
+  { label: '청약', href: '/dashboard/subscriptions', icon: CalendarDays },
+];
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // 단지 검색 debounce
+  useEffect(() => {
+    if (query.length < 2) return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `/api/market/apartments?q=${encodeURIComponent(query)}&limit=8`,
+          { signal: controller.signal }
+        );
+        const data = await res.json();
+        setResults(data.data?.map((a: { id: string; name: string; dong: string; regionCode: string }) => ({
+          id: a.id,
+          name: a.name,
+          dong: a.dong,
+          regionCode: a.regionCode,
+        })) || []);
+      } catch {
+        if (!controller.signal.aborted) setResults([]);
+      }
+      setLoading(false);
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query]);
+
+  // 쿼리 초기화 시 결과 비우기
+  const handleQueryChange = useCallback((value: string) => {
+    setQuery(value);
+    if (value.length < 2) setResults([]);
+  }, []);
+
+  const go = useCallback(
+    (href: string) => {
+      onOpenChange(false);
+      setQuery('');
+      router.push(href);
+    },
+    [router, onOpenChange]
+  );
+
+  return (
+    <Command.Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      label="검색"
+      className="fixed inset-0 z-50"
+    >
+      {/* 백드롭 */}
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={() => onOpenChange(false)} />
+
+      {/* 패널 */}
+      <div className="fixed left-1/2 top-[20%] z-50 w-full max-w-lg -translate-x-1/2">
+        <div className="rounded-2xl border border-border/50 bg-white shadow-2xl overflow-hidden">
+          {/* 검색 입력 */}
+          <div className="flex items-center gap-3 border-b px-4 py-3">
+            <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Command.Input
+              value={query}
+              onValueChange={handleQueryChange}
+              placeholder="단지명, 메뉴 검색..."
+              className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+            <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
+              ESC
+            </kbd>
+          </div>
+
+          {/* 결과 */}
+          <Command.List className="max-h-80 overflow-y-auto p-2">
+            <Command.Empty className="py-6 text-center text-sm text-muted-foreground">
+              {loading ? '검색 중...' : query.length < 2 ? '2글자 이상 입력하세요' : '검색 결과가 없습니다'}
+            </Command.Empty>
+
+            {/* 단지 검색 결과 */}
+            {results.length > 0 && (
+              <Command.Group heading="아파트 단지">
+                {results.map((r) => (
+                  <Command.Item
+                    key={r.id}
+                    value={`${r.name} ${r.dong}`}
+                    onSelect={() => go(`/dashboard/apartments/${r.id}`)}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm cursor-pointer aria-selected:bg-accent"
+                  >
+                    <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <div>
+                      <p className="font-medium">{r.name}</p>
+                      <p className="text-xs text-muted-foreground">{r.dong}</p>
+                    </div>
+                  </Command.Item>
+                ))}
+              </Command.Group>
+            )}
+
+            {/* 메뉴 */}
+            <Command.Group heading="메뉴">
+              {MENU_ITEMS.map((item) => (
+                <Command.Item
+                  key={item.href}
+                  value={item.label}
+                  onSelect={() => go(item.href)}
+                  className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm cursor-pointer aria-selected:bg-accent"
+                >
+                  <item.icon className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <span>{item.label}</span>
+                </Command.Item>
+              ))}
+            </Command.Group>
+          </Command.List>
+        </div>
+      </div>
+    </Command.Dialog>
+  );
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -38,7 +38,7 @@ const NAV_GROUPS = [
   },
 ];
 
-export function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
+export function Sidebar({ onNavigate, onCommandOpen }: { onNavigate?: () => void; onCommandOpen?: () => void }) {
   const pathname = usePathname();
 
   return (
@@ -61,6 +61,7 @@ export function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
       {/* Search trigger */}
       <div className="px-4 pb-2">
         <button
+          onClick={onCommandOpen}
           className="w-full flex items-center gap-2 rounded-xl h-8 px-2.5 bg-primary/[0.04] border border-primary/20 hover:border-primary/40 hover:bg-primary/[0.07] transition-all text-xs text-foreground/50 hover:text-foreground/80"
         >
           <Search className="h-3.5 w-3.5 shrink-0" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}


### PR DESCRIPTION
## Summary
marketlab 패턴의 커맨드 팔레트 — 단지명 검색 + 메뉴 이동

## 사용법
- `⌘K` / `Ctrl+K` — 팔레트 열기
- 사이드바 검색 버튼 클릭
- 단지명 입력 → 실시간 검색 (300ms debounce)
- 화살표 키 + Enter로 선택
- ESC 또는 백드롭 클릭으로 닫기

## 검색 대상
- 아파트 단지 (API 연동, 최대 8개)
- 메뉴 6개 (시장 개요, 지도 탐색, 아파트, 금리 동향, 가격지수, 청약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 커맨드 팔레트 기능 추가: Cmd/Ctrl + K 단축키로 빠르게 접근 가능
  * 커맨드 팔레트를 통한 아파트 검색 및 빠른 네비게이션

<!-- end of auto-generated comment: release notes by coderabbit.ai -->