### PR TITLE
feat: 관심 단지 + 최근 본 단지 + 맞춤 지역 + 마이페이지

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,8 @@ model User {
   updatedAt     DateTime  @updatedAt @map("updated_at")
 
   watchlist     UserWatchlist[]
+  history       UserHistory[]
+  settings      UserSettings?
 
   @@map("users")
 }
@@ -34,6 +36,31 @@ model UserWatchlist {
   @@unique([userId, complexId])
   @@index([userId])
   @@map("user_watchlist")
+}
+
+model UserHistory {
+  id          String   @id @default(cuid())
+  userId      String   @map("user_id")
+  complexId   String   @map("complex_id")
+  viewedAt    DateTime @default(now()) @map("viewed_at")
+
+  user    User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  complex ApartmentComplex @relation(fields: [complexId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, complexId])
+  @@index([userId, viewedAt])
+  @@map("user_history")
+}
+
+model UserSettings {
+  id          String   @id @default(cuid())
+  userId      String   @unique @map("user_id")
+  regionCodes String[] @default([]) @map("region_codes")  // 맞춤 지역 코드
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("user_settings")
 }
 
 // ─── 법정동코드 ──────────────────────────────────────────────
@@ -72,6 +99,7 @@ model ApartmentComplex {
   region        Region @relation(fields: [regionCode], references: [code])
   trades        ApartmentTrade[]
   watchedBy     UserWatchlist[]
+  viewedBy      UserHistory[]
 
   @@unique([regionCode, name, dong, jibun])
   @@index([regionCode])

--- a/src/app/(dashboard)/dashboard/apartments/[id]/_components/history-tracker.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/_components/history-tracker.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+
+/** 단지 상세 페이지 방문 시 히스토리 자동 기록 */
+export function HistoryTracker({ complexId }: { complexId: string }) {
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (!session?.user) return;
+
+    fetch('/api/user/history', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ complexId }),
+    }).catch(() => {});
+  }, [session, complexId]);
+
+  return null;
+}

--- a/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
@@ -7,6 +7,8 @@ import { Building2, MapPin, Calendar, ArrowLeft } from 'lucide-react';
 import { PriceChart } from './_components/price-chart';
 import { TradeTable } from './_components/trade-table';
 import { AreaComparison } from './_components/area-comparison';
+import { WatchlistButton } from '@/components/watchlist-button';
+import { HistoryTracker } from './_components/history-tracker';
 
 export const dynamic = 'force-dynamic';
 
@@ -63,6 +65,9 @@ export default async function ApartmentDetailPage({ params }: PageProps) {
 
   return (
     <div className="space-y-6">
+      {/* 히스토리 자동 기록 */}
+      <HistoryTracker complexId={id} />
+
       {/* Back + Header */}
       <div>
         <Link
@@ -76,8 +81,11 @@ export default async function ApartmentDetailPage({ params }: PageProps) {
           <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10">
             <Building2 className="h-6 w-6 text-primary" />
           </div>
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">{complex.name}</h1>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold tracking-tight">{complex.name}</h1>
+              <WatchlistButton complexId={id} />
+            </div>
             <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
               <span className="inline-flex items-center gap-1">
                 <MapPin className="h-3.5 w-3.5" />

--- a/src/app/(dashboard)/dashboard/my/page.tsx
+++ b/src/app/(dashboard)/dashboard/my/page.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import useSWR from 'swr';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Building2, Clock, Heart, User } from 'lucide-react';
+import { formatPrice } from '@/lib/format';
+import { WatchlistButton } from '@/components/watchlist-button';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+interface WatchlistItem {
+  id: string;
+  complexId: string;
+  complex: {
+    id: string;
+    name: string;
+    dong: string;
+    builtYear: number | null;
+    region: { sido: string; sigungu: string };
+    _count: { trades: number };
+    trades: { price: number; area: number; dealDate: string }[];
+  };
+}
+
+interface HistoryItem {
+  id: string;
+  complexId: string;
+  viewedAt: string;
+  complex: {
+    id: string;
+    name: string;
+    dong: string;
+    region: { sido: string; sigungu: string };
+    trades: { price: number; area: number }[];
+  };
+}
+
+export default function MyPage() {
+  const { data: session, status } = useSession();
+  const { data: watchlistData } = useSWR<{ data: WatchlistItem[] }>(
+    session ? '/api/user/watchlist' : null,
+    fetcher
+  );
+  const { data: historyData } = useSWR<{ data: HistoryItem[] }>(
+    session ? '/api/user/history' : null,
+    fetcher
+  );
+
+  if (status === 'loading') {
+    return (
+      <div className="space-y-6">
+        <div className="h-8 w-32 animate-pulse rounded bg-muted" />
+        <div className="h-64 animate-pulse rounded-xl bg-muted/60" />
+      </div>
+    );
+  }
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  const watchlist = watchlistData?.data || [];
+  const history = historyData?.data || [];
+
+  return (
+    <div className="space-y-6">
+      {/* 프로필 */}
+      <div className="flex items-center gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+          <User className="h-6 w-6 text-primary" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">
+            {session.user?.name || '사용자'}
+          </h1>
+          <p className="text-sm text-muted-foreground">{session.user?.email}</p>
+        </div>
+      </div>
+
+      {/* 관심 단지 */}
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2 pb-3">
+          <Heart className="h-4 w-4 text-red-500" />
+          <CardTitle className="text-base">관심 단지 ({watchlist.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {watchlist.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              아직 관심 단지가 없습니다. 단지 상세 페이지에서 ♥를 눌러 추가해보세요.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {watchlist.map((item) => {
+                const latest = item.complex.trades[0];
+                return (
+                  <div
+                    key={item.id}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-accent/50 transition-colors"
+                  >
+                    <Link
+                      href={`/dashboard/apartments/${item.complexId}`}
+                      className="flex items-center gap-3 min-w-0 flex-1"
+                    >
+                      <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium truncate">{item.complex.name}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {item.complex.region.sigungu} {item.complex.dong}
+                          {item.complex.builtYear && ` · ${item.complex.builtYear}년`}
+                        </p>
+                      </div>
+                      {latest && (
+                        <div className="text-right shrink-0">
+                          <p className="text-sm font-semibold text-primary">
+                            {formatPrice(latest.price)}
+                          </p>
+                          <p className="text-[10px] text-muted-foreground">
+                            {item.complex._count.trades}건
+                          </p>
+                        </div>
+                      )}
+                    </Link>
+                    <WatchlistButton complexId={item.complexId} size="sm" />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 최근 본 단지 */}
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2 pb-3">
+          <Clock className="h-4 w-4 text-muted-foreground" />
+          <CardTitle className="text-base">최근 본 단지</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {history.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              아직 조회한 단지가 없습니다.
+            </p>
+          ) : (
+            <div className="space-y-1">
+              {history.map((item) => {
+                const latest = item.complex.trades[0];
+                return (
+                  <Link
+                    key={item.id}
+                    href={`/dashboard/apartments/${item.complexId}`}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-accent/50 transition-colors"
+                  >
+                    <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium truncate">{item.complex.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {item.complex.region.sigungu} {item.complex.dong}
+                      </p>
+                    </div>
+                    {latest && (
+                      <Badge variant="secondary" className="text-[10px] shrink-0">
+                        {formatPrice(latest.price)}
+                      </Badge>
+                    )}
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {new Date(item.viewedAt).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/user/history/route.ts
+++ b/src/app/api/user/history/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { auth } from '@/lib/next-auth';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/user/history — 최근 본 단지 (최대 20개) */
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const items = await prisma.userHistory.findMany({
+    where: { userId: session.user.id },
+    include: {
+      complex: {
+        include: {
+          region: { select: { sido: true, sigungu: true } },
+          trades: {
+            orderBy: { dealDate: 'desc' },
+            take: 1,
+            select: { price: true, area: true },
+          },
+        },
+      },
+    },
+    orderBy: { viewedAt: 'desc' },
+    take: 20,
+  });
+
+  return NextResponse.json({ data: items });
+}
+
+/** POST /api/user/history — 최근 본 단지 기록 (upsert) */
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { complexId } = await request.json();
+  if (!complexId) {
+    return NextResponse.json({ error: 'complexId 필수' }, { status: 400 });
+  }
+
+  const item = await prisma.userHistory.upsert({
+    where: {
+      userId_complexId: { userId: session.user.id, complexId },
+    },
+    update: { viewedAt: new Date() },
+    create: { userId: session.user.id, complexId },
+  });
+
+  return NextResponse.json({ data: item });
+}

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { auth } from '@/lib/next-auth';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/user/settings — 사용자 설정 조회 */
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const settings = await prisma.userSettings.findUnique({
+    where: { userId: session.user.id },
+  });
+
+  return NextResponse.json({ data: settings || { regionCodes: [] } });
+}
+
+/** PUT /api/user/settings — 사용자 설정 저장 */
+export async function PUT(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { regionCodes } = await request.json();
+
+  const settings = await prisma.userSettings.upsert({
+    where: { userId: session.user.id },
+    update: { regionCodes: regionCodes || [] },
+    create: { userId: session.user.id, regionCodes: regionCodes || [] },
+  });
+
+  return NextResponse.json({ data: settings });
+}

--- a/src/app/api/user/watchlist/route.ts
+++ b/src/app/api/user/watchlist/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { auth } from '@/lib/next-auth';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/user/watchlist — 관심 단지 목록 */
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const items = await prisma.userWatchlist.findMany({
+    where: { userId: session.user.id },
+    include: {
+      complex: {
+        include: {
+          region: { select: { sido: true, sigungu: true } },
+          _count: { select: { trades: true } },
+          trades: {
+            orderBy: { dealDate: 'desc' },
+            take: 1,
+            select: { price: true, area: true, dealDate: true },
+          },
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return NextResponse.json({ data: items });
+}
+
+/** POST /api/user/watchlist — 관심 단지 추가 */
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { complexId } = await request.json();
+  if (!complexId) {
+    return NextResponse.json({ error: 'complexId 필수' }, { status: 400 });
+  }
+
+  try {
+    const item = await prisma.userWatchlist.create({
+      data: { userId: session.user.id, complexId },
+    });
+    return NextResponse.json({ data: item }, { status: 201 });
+  } catch {
+    // unique 제약 위반 (이미 등록됨)
+    return NextResponse.json({ error: '이미 관심 단지에 등록되어 있습니다.' }, { status: 409 });
+  }
+}
+
+/** DELETE /api/user/watchlist?complexId=xxx — 관심 단지 삭제 */
+export async function DELETE(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const complexId = request.nextUrl.searchParams.get('complexId');
+  if (!complexId) {
+    return NextResponse.json({ error: 'complexId 필수' }, { status: 400 });
+  }
+
+  await prisma.userWatchlist.deleteMany({
+    where: { userId: session.user.id, complexId },
+  });
+
+  return NextResponse.json({ data: { deleted: true } });
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Home,
   CalendarDays,
   Search,
+  Heart,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -34,6 +35,12 @@ const NAV_GROUPS = [
     items: [
       { href: '/dashboard/rates', label: '금리 동향', icon: Landmark },
       { href: '/dashboard/indices', label: '가격지수', icon: TrendingUp },
+    ],
+  },
+  {
+    label: 'My',
+    items: [
+      { href: '/dashboard/my', label: '관심 단지', icon: Heart },
     ],
   },
 ];

--- a/src/components/watchlist-button.tsx
+++ b/src/components/watchlist-button.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { Heart } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface WatchlistButtonProps {
+  complexId: string;
+  size?: 'sm' | 'md';
+}
+
+export function WatchlistButton({ complexId, size = 'md' }: WatchlistButtonProps) {
+  const { data: session } = useSession();
+  const [isWatched, setIsWatched] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!session?.user) return;
+
+    fetch('/api/user/watchlist')
+      .then((r) => r.json())
+      .then((data) => {
+        const ids = (data.data || []).map((w: { complexId: string }) => w.complexId);
+        setIsWatched(ids.includes(complexId));
+      })
+      .catch(() => {});
+  }, [session, complexId]);
+
+  if (!session?.user) return null;
+
+  const toggle = async () => {
+    setLoading(true);
+    try {
+      if (isWatched) {
+        await fetch(`/api/user/watchlist?complexId=${complexId}`, { method: 'DELETE' });
+        setIsWatched(false);
+      } else {
+        await fetch('/api/user/watchlist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ complexId }),
+        });
+        setIsWatched(true);
+      }
+    } catch {
+      // 무시
+    }
+    setLoading(false);
+  };
+
+  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
+  const btnSize = size === 'sm' ? 'h-7 w-7' : 'h-8 w-8';
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={loading}
+      className={cn(
+        'flex items-center justify-center rounded-full transition-all shrink-0',
+        btnSize,
+        isWatched
+          ? 'bg-red-50 text-red-500 hover:bg-red-100'
+          : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+      )}
+      title={isWatched ? '관심 단지 해제' : '관심 단지 추가'}
+    >
+      <Heart
+        className={cn(iconSize, isWatched && 'fill-current')}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
로그인 기반 회원 기능 3종 + 마이페이지

## 기능

### 1. 관심 단지 (♥)
- 단지 상세 페이지 헤더에 ♥ 버튼
- 클릭으로 추가/해제 토글
- 마이페이지에서 목록 관리

### 2. 최근 본 단지
- 단지 상세 페이지 방문 시 자동 기록 (HistoryTracker)
- upsert로 중복 방지, viewedAt 갱신
- 마이페이지에서 최근 20개 표시

### 3. 맞춤 지역 설정
- regionCodes 배열로 관심 지역 저장
- GET/PUT /api/user/settings

### 4. 마이페이지 (/dashboard/my)
- 프로필 (이름, 이메일)
- 관심 단지 목록 (최신 가격 + ♥ 해제)
- 최근 본 단지 목록 (방문일 표시)

## DB
- `user_history` — userId + complexId (unique), viewedAt
- `user_settings` — userId (unique), regionCodes[]

🤖 Generated with [Claude Code](https://claude.com/claude-code)