### PR TITLE
feat: 아파트 상세 페이지 개선

### DIFF
--- a/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
@@ -1,9 +1,12 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
-import { pricePerPyeong } from '@/lib/calculations';
+import { pricePerPyeong, toPyeong } from '@/lib/calculations';
+import { formatPrice } from '@/lib/format';
 import { Card, CardContent } from '@/components/ui/card';
-import { Building2, MapPin, Calendar, ArrowLeft } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Building2, MapPin, Calendar, ArrowLeft, Map, TrendingUp, TrendingDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { PriceChart } from './_components/price-chart';
 import { TradeTable } from './_components/trade-table';
 import { AreaComparison } from './_components/area-comparison';
@@ -15,6 +18,13 @@ export const dynamic = 'force-dynamic';
 
 interface PageProps {
   params: Promise<{ id: string }>;
+}
+
+function getPriceColor(price: number): { bg: string; text: string } {
+  if (price >= 200000) return { bg: 'bg-violet-500/10', text: 'text-violet-600' };
+  if (price >= 100000) return { bg: 'bg-blue-500/10', text: 'text-blue-600' };
+  if (price >= 50000) return { bg: 'bg-emerald-500/10', text: 'text-emerald-600' };
+  return { bg: 'bg-slate-500/10', text: 'text-slate-600' };
 }
 
 export default async function ApartmentDetailPage({ params }: PageProps) {
@@ -34,23 +44,22 @@ export default async function ApartmentDetailPage({ params }: PageProps) {
   if (!complex) notFound();
 
   // 면적별 그룹핑
-  const areaMap = new Map<number, { count: number; totalPrice: number; totalPPP: number }>();
+  const areaRecord: Record<number, { count: number; totalPrice: number; totalPPP: number }> = {};
   for (const trade of complex.trades) {
     const areaKey = Math.round(trade.area);
     const ppp = pricePerPyeong(trade.price, trade.area);
-    const existing = areaMap.get(areaKey);
-    if (existing) {
-      existing.count++;
-      existing.totalPrice += trade.price;
-      existing.totalPPP += ppp;
+    if (areaRecord[areaKey]) {
+      areaRecord[areaKey].count++;
+      areaRecord[areaKey].totalPrice += trade.price;
+      areaRecord[areaKey].totalPPP += ppp;
     } else {
-      areaMap.set(areaKey, { count: 1, totalPrice: trade.price, totalPPP: ppp });
+      areaRecord[areaKey] = { count: 1, totalPrice: trade.price, totalPPP: ppp };
     }
   }
 
-  const areaGroups = Array.from(areaMap.entries())
+  const areaGroups = Object.entries(areaRecord)
     .map(([area, { count, totalPrice, totalPPP }]) => ({
-      area,
+      area: Number(area),
       count,
       avgPrice: Math.round(totalPrice / count),
       avgPricePerPyeong: Math.round(totalPPP / count),
@@ -62,80 +71,116 @@ export default async function ApartmentDetailPage({ params }: PageProps) {
   const avgPrice = tradeCount
     ? Math.round(complex.trades.reduce((s, t) => s + t.price, 0) / tradeCount)
     : 0;
+  const maxPrice = tradeCount ? Math.max(...complex.trades.map((t) => t.price)) : 0;
+  const minPrice = tradeCount ? Math.min(...complex.trades.map((t) => t.price)) : 0;
   const latestTrade = complex.trades[0];
+  const color = getPriceColor(avgPrice);
+
+  // 층별 분석
+  const floorGroups = [
+    { label: '저층 (1~3층)', trades: complex.trades.filter((t) => t.floor >= 1 && t.floor <= 3), color: '#93c5fd' },
+    { label: '중층 (4~10층)', trades: complex.trades.filter((t) => t.floor >= 4 && t.floor <= 10), color: '#2563eb' },
+    { label: '고층 (11층+)', trades: complex.trades.filter((t) => t.floor >= 11), color: '#7c3aed' },
+  ]
+    .map((g) => ({
+      ...g,
+      avg: g.trades.length > 0 ? Math.round(g.trades.reduce((s, t) => s + t.price, 0) / g.trades.length) : 0,
+      count: g.trades.length,
+    }))
+    .filter((g) => g.count > 0);
+
+  const floorMaxAvg = Math.max(...floorGroups.map((g) => g.avg));
+  const floorPremium = floorGroups.length >= 2
+    ? Math.round(((floorGroups[floorGroups.length - 1].avg - floorGroups[0].avg) / floorGroups[0].avg) * 100)
+    : 0;
 
   return (
-    <div className="space-y-6">
-      {/* 히스토리 자동 기록 */}
+    <div className="space-y-6 max-w-5xl mx-auto">
       <HistoryTracker complexId={id} />
 
-      {/* Back + Header */}
+      {/* Header */}
       <div>
         <Link
           href="/dashboard/apartments"
-          className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          className="mb-4 inline-flex items-center gap-1.5 text-[13px] text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
           목록으로
         </Link>
         <div className="flex items-start gap-4">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10">
-            <Building2 className="h-6 w-6 text-primary" />
+          <div className={cn('flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl', color.bg)}>
+            <Building2 className={cn('h-7 w-7', color.text)} />
           </div>
           <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-bold tracking-tight">{complex.name}</h1>
+            <div className="flex items-center gap-3">
+              <h1 className="text-3xl font-bold tracking-tight">{complex.name}</h1>
               <WatchlistButton complexId={id} />
             </div>
-            <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              <span className="inline-flex items-center gap-1">
-                <MapPin className="h-3.5 w-3.5" />
+            <div className="mt-2 flex flex-wrap items-center gap-3 text-[14px] text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <MapPin className="h-4 w-4" />
                 {complex.region.sido} {complex.region.sigungu} {complex.dong}
               </span>
               {complex.builtYear && (
-                <span className="inline-flex items-center gap-1">
-                  <Calendar className="h-3.5 w-3.5" />
+                <span className="inline-flex items-center gap-1.5">
+                  <Calendar className="h-4 w-4" />
                   {complex.builtYear}년 건축
                 </span>
               )}
+              {complex.lat && complex.lng && (
+                <Link
+                  href="/dashboard/map"
+                  className="inline-flex items-center gap-1.5 text-primary hover:underline"
+                >
+                  <Map className="h-4 w-4" />
+                  지도에서 보기
+                </Link>
+              )}
             </div>
+            {complex.roadAddress && (
+              <p className="text-[13px] text-muted-foreground mt-1">{complex.roadAddress}</p>
+            )}
           </div>
         </div>
       </div>
 
-      {/* Stats cards */}
-      <div className="grid gap-4 sm:grid-cols-3">
+      {/* Stats */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <Card>
-          <CardContent className="p-4">
-            <p className="text-sm text-muted-foreground">평균 매매가</p>
-            <p className="text-2xl font-bold text-primary">
-              {(avgPrice / 10000).toFixed(1)}
-              <span className="ml-1 text-sm font-normal text-muted-foreground">억</span>
+          <CardContent className="p-5">
+            <p className="text-[13px] text-muted-foreground">평균 매매가</p>
+            <p className={cn('text-2xl font-bold mt-1', color.text)}>{formatPrice(avgPrice)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-5">
+            <p className="text-[13px] text-muted-foreground">최고 / 최저</p>
+            <p className="text-2xl font-bold mt-1">
+              {formatPrice(maxPrice)}
+              <span className="text-[14px] font-normal text-muted-foreground mx-1">/</span>
+              {formatPrice(minPrice)}
             </p>
           </CardContent>
         </Card>
         <Card>
-          <CardContent className="p-4">
-            <p className="text-sm text-muted-foreground">거래 건수</p>
-            <p className="text-2xl font-bold">{tradeCount}건</p>
+          <CardContent className="p-5">
+            <p className="text-[13px] text-muted-foreground">거래 건수</p>
+            <p className="text-2xl font-bold mt-1">{tradeCount}건</p>
+            <p className="text-[12px] text-muted-foreground">{areaGroups.length}개 면적 타입</p>
           </CardContent>
         </Card>
         <Card>
-          <CardContent className="p-4">
-            <p className="text-sm text-muted-foreground">최근 거래</p>
+          <CardContent className="p-5">
+            <p className="text-[13px] text-muted-foreground">최근 거래</p>
             {latestTrade ? (
               <div>
-                <p className="text-2xl font-bold">
-                  {(latestTrade.price / 10000).toFixed(1)}
-                  <span className="ml-1 text-sm font-normal text-muted-foreground">억</span>
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {latestTrade.area}㎡ · {latestTrade.floor}층 ·{' '}
-                  {latestTrade.dealDate.toISOString().slice(0, 10)}
+                <p className="text-2xl font-bold mt-1">{formatPrice(latestTrade.price)}</p>
+                <p className="text-[12px] text-muted-foreground">
+                  {latestTrade.area}㎡ ({Math.round(toPyeong(latestTrade.area))}평) · {latestTrade.floor}층 · {latestTrade.dealDate.toISOString().slice(0, 10)}
                 </p>
               </div>
             ) : (
-              <p className="text-2xl font-bold text-muted-foreground">—</p>
+              <p className="text-2xl font-bold text-muted-foreground mt-1">—</p>
             )}
           </CardContent>
         </Card>
@@ -143,14 +188,64 @@ export default async function ApartmentDetailPage({ params }: PageProps) {
 
       {/* Charts */}
       <div className="grid gap-4 lg:grid-cols-2">
-        <PriceChart trades={complex.trades.map((t) => ({
-          dealDate: t.dealDate.toISOString(),
-          price: t.price,
-          area: t.area,
-          floor: t.floor,
-        }))} />
-        <AreaComparison areaGroups={areaGroups} />
+        <Card>
+          <CardContent className="p-5">
+            <PriceChart trades={complex.trades.map((t) => ({
+              dealDate: t.dealDate.toISOString(),
+              price: t.price,
+              area: t.area,
+              floor: t.floor,
+            }))} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-5">
+            <AreaComparison areaGroups={areaGroups} />
+          </CardContent>
+        </Card>
       </div>
+
+      {/* 층별 분석 */}
+      {floorGroups.length >= 2 && (
+        <Card>
+          <CardContent className="p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-[16px] font-bold">층별 가격 분석</h2>
+              {floorPremium !== 0 && (
+                <span className={cn(
+                  'rounded-full px-3 py-1 text-[13px] font-semibold',
+                  floorPremium > 0 ? 'bg-red-50 text-red-600' : 'bg-blue-50 text-blue-600'
+                )}>
+                  {floorPremium > 0 ? <TrendingUp className="h-3.5 w-3.5 inline mr-1" /> : <TrendingDown className="h-3.5 w-3.5 inline mr-1" />}
+                  고층 프리미엄 {floorPremium > 0 ? '+' : ''}{floorPremium}%
+                </span>
+              )}
+            </div>
+            <div className="space-y-4">
+              {floorGroups.map((g) => {
+                const widthPct = (g.avg / floorMaxAvg) * 100;
+                return (
+                  <div key={g.label} className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-[14px] font-medium">{g.label}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-[16px] font-bold">{formatPrice(g.avg)}</span>
+                        <Badge variant="outline" className="text-[11px]">{g.count}건</Badge>
+                      </div>
+                    </div>
+                    <div className="h-3 rounded-full bg-muted">
+                      <div
+                        className="h-3 rounded-full transition-all"
+                        style={{ width: `${widthPct}%`, backgroundColor: g.color }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Nearby facilities */}
       <NearbyFacilities complexId={id} />


### PR DESCRIPTION
## Summary
- 아파트 상세 페이지 UI 개선 + 층별 가격 분석 추가

## Changes
- 통계 카드 3개→4개 (평균/최고·최저/거래건수/최근거래)
- 가격대별 컬러 아이콘 적용
- 층별 가격 분석 (저층/중층/고층 바 차트 + 고층 프리미엄 %)
- "지도에서 보기" 링크
- 레이아웃 max-w-5xl, 폰트 확대

## Test plan
- [ ] 아파트 상세 페이지 접근 확인
- [ ] 층별 분석 바 차트 표시
- [ ] 지도에서 보기 링크 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 아파트 상세 정보 페이지 개선

* **새로운 기능**
  * 지도에서 보기 링크 추가 (위치 정보 있을 때)
  * 층별 가격 분석 카드 신규 추가 (고층 프리미엄 지표 포함)
  * 도로명 주소 표시 추가

* **개선사항**
  * 통계 섹션을 카드 그리드로 재설계 (평균·최고·최저 가격 포함)
  * 가격 범위에 따른 동적 헤더 색상 적용
  * 거래 정보를 평수 단위로 표시
  * 차트 컨테이너 카드로 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->