### PR TITLE
fix: 지도 드래그 안 되는 문제 수정

### DIFF
--- a/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/trade-map.tsx
@@ -837,13 +837,13 @@ export function TradeMap() {
   return (
     <div className="relative h-full">
       {/* 시도 선택 탭 */}
-      <div className="absolute top-3 left-3 z-[20] flex gap-1.5 max-w-[calc(100%-100px)] md:max-w-[calc(100%-140px)] overflow-x-auto scrollbar-none md:flex-wrap">
+      <div className="absolute top-3 left-3 z-[20] flex gap-1.5 max-w-[calc(100%-100px)] md:max-w-[calc(100%-140px)] overflow-x-auto scrollbar-none md:flex-wrap pointer-events-none">
         {sidoList.map((sido) => (
           <button
             key={sido}
             onClick={() => moveTo(sido)}
             className={cn(
-              'rounded-lg px-2.5 py-1.5 text-[11px] font-medium shadow-sm transition-all',
+              'rounded-lg px-2.5 py-1.5 text-[11px] font-medium shadow-sm transition-all pointer-events-auto',
               selectedSido === sido
                 ? 'bg-primary text-primary-foreground'
                 : 'bg-white/95 text-foreground/70 hover:bg-white backdrop-blur-sm border border-border/50'
@@ -855,7 +855,7 @@ export function TradeMap() {
       </div>
 
       {/* 우측 컨트롤 */}
-      <div className="absolute top-3 right-3 z-[20] flex flex-col gap-1.5">
+      <div className="absolute top-3 right-3 z-[20] flex flex-col gap-1.5 pointer-events-none [&>*]:pointer-events-auto">
         {/* 단지 리스트 */}
         <button
           onClick={() => {
@@ -1127,7 +1127,7 @@ export function TradeMap() {
       )}
 
       {/* 하단 상태바 */}
-      <div className="absolute bottom-8 left-3 z-[20] flex items-center gap-2">
+      <div className="absolute bottom-8 left-3 z-[20] flex items-center gap-2 pointer-events-none [&>*]:pointer-events-auto">
         <div className="rounded-lg bg-white/95 backdrop-blur-sm border border-border/50 px-3 py-1.5 shadow-sm text-[11px] flex items-center gap-3">
           <span>
             <span className="font-semibold text-primary">{withCoords.length}</span> 단지


### PR DESCRIPTION
## Summary
- 지도 위 UI 요소가 마우스/터치 이벤트를 가로채서 지도 드래그가 안 되던 문제 수정

## Changes
- 시도 탭, 우측 컨트롤, 하단 상태바 컨테이너에 `pointer-events-none` 적용
- 각 버튼/카드에만 `pointer-events-auto`로 클릭 허용
- 버튼 외 투명 영역은 지도로 이벤트가 통과

## Test plan
- [ ] 지도 드래그 (마우스/터치) 동작 확인
- [ ] 시도 탭 클릭 동작 확인
- [ ] 우측 컨트롤 (줌, 위성, 지적편집도) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 지도 대시보드의 UI 컨트롤 요소들의 사용자 상호작용 반응성을 개선했습니다. 지역 선택 탭, 우측 컨트롤, 하단 상태바 등 여러 컨트롤 영역에서 클릭 및 상호작용이 더욱 안정적으로 작동하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->