### PR TITLE
feat: 동네 시세 순위 + 회전율 분석

### DIFF
--- a/src/app/(dashboard)/dashboard/apartments/[id]/_components/rank-card.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/_components/rank-card.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import useSWR from 'swr';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+interface RankData {
+  myRank: number;
+  totalInRegion: number;
+  percentile: number;
+  myAvgPpp: number;
+  turnoverRate: number | null;
+  recentTrades: number;
+  totalUnits: number | null;
+  top3: { id: string; name: string; avgPpp: number }[];
+  nearMe: { id: string; name: string; avgPpp: number }[];
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export function RankCard({ complexId }: { complexId: string }) {
+  const { data } = useSWR<{ data: RankData | null }>(
+    `/api/market/apartments/${complexId}/rank`,
+    fetcher
+  );
+
+  if (!data?.data) return null;
+
+  const { myRank, totalInRegion, percentile, myAvgPpp, turnoverRate, recentTrades, totalUnits, top3 } = data.data;
+
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <h2 className="text-[16px] font-bold mb-4">동네 시세 순위</h2>
+
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          <div className="text-center rounded-xl bg-primary/5 p-3">
+            <p className="text-[13px] text-muted-foreground">순위</p>
+            <p className="text-2xl font-bold mt-1">
+              <span className="text-primary">{myRank}</span>
+              <span className="text-[14px] font-normal text-muted-foreground">/{totalInRegion}</span>
+            </p>
+            <p className="text-[12px] text-muted-foreground">상위 {percentile}%</p>
+          </div>
+          <div className="text-center rounded-xl bg-muted/50 p-3">
+            <p className="text-[13px] text-muted-foreground">평당가</p>
+            <p className="text-2xl font-bold mt-1">{myAvgPpp.toLocaleString()}</p>
+            <p className="text-[12px] text-muted-foreground">만원/평</p>
+          </div>
+          <div className="text-center rounded-xl bg-muted/50 p-3">
+            <p className="text-[13px] text-muted-foreground">회전율</p>
+            {turnoverRate !== null ? (
+              <>
+                <p className={cn(
+                  'text-2xl font-bold mt-1',
+                  turnoverRate >= 10 ? 'text-red-500' : turnoverRate >= 5 ? 'text-amber-500' : 'text-blue-500'
+                )}>
+                  {turnoverRate}%
+                </p>
+                <p className="text-[12px] text-muted-foreground">{recentTrades}건/{totalUnits}세대</p>
+              </>
+            ) : (
+              <p className="text-xl font-bold text-muted-foreground mt-1">—</p>
+            )}
+          </div>
+        </div>
+
+        {/* 상위 3개 단지 */}
+        {top3.length > 0 && (
+          <div>
+            <p className="text-[13px] font-semibold text-muted-foreground mb-2">지역 TOP 3</p>
+            <div className="space-y-1.5">
+              {top3.map((item, idx) => (
+                <div key={item.id} className="flex items-center justify-between rounded-lg px-3 py-2 bg-muted/30">
+                  <div className="flex items-center gap-2">
+                    <span className={cn(
+                      'flex items-center justify-center h-6 w-6 rounded-full text-[11px] font-bold',
+                      idx === 0 ? 'bg-amber-500/20 text-amber-600' : 'bg-muted text-muted-foreground'
+                    )}>
+                      {idx + 1}
+                    </span>
+                    <span className="text-[13px] font-medium truncate">{item.name}</span>
+                  </div>
+                  <span className="text-[13px] font-bold tabular-nums">{item.avgPpp.toLocaleString()}만/평</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/apartments/[id]/page.tsx
@@ -13,6 +13,7 @@ import { AreaComparison } from './_components/area-comparison';
 import { WatchlistButton } from '@/components/watchlist-button';
 import { HistoryTracker } from './_components/history-tracker';
 import { NearbyFacilities } from './_components/nearby-facilities';
+import { RankCard } from './_components/rank-card';
 
 export const dynamic = 'force-dynamic';
 
@@ -246,6 +247,9 @@ export default async function ApartmentDetailPage({ params }: PageProps) {
           </CardContent>
         </Card>
       )}
+
+      {/* 동네 시세 순위 + 회전율 */}
+      <RankCard complexId={id} />
 
       {/* Nearby facilities */}
       <NearbyFacilities complexId={id} />

--- a/src/app/(dashboard)/dashboard/map/_components/complex-detail-panel.tsx
+++ b/src/app/(dashboard)/dashboard/map/_components/complex-detail-panel.tsx
@@ -222,6 +222,17 @@ export function ComplexDetailPanel({ complexId, onClose, onTabChange }: Props) {
     fetcher
   );
 
+  interface RankData {
+    myRank: number; totalInRegion: number; percentile: number; myAvgPpp: number;
+    turnoverRate: number | null; recentTrades: number; totalUnits: number | null;
+    top3: { id: string; name: string; avgPpp: number }[];
+    nearMe: { id: string; name: string; avgPpp: number }[];
+  }
+  const { data: rankData } = useSWR<{ data: RankData | null }>(
+    complexId ? `/api/market/apartments/${complexId}/rank` : null,
+    fetcher
+  );
+
   // ESC 키로 닫기
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -379,6 +390,45 @@ export function ComplexDetailPanel({ complexId, onClose, onTabChange }: Props) {
             {/* === 개요 탭 === */}
             {activeTab === 'overview' && (
               <>
+                {/* 순위 + 회전율 */}
+                {rankData?.data && (
+                  <div className="px-5 py-4 border-b bg-muted/20">
+                    <div className="grid grid-cols-3 gap-3">
+                      {/* 시세 순위 */}
+                      <div className="text-center">
+                        <p className="text-[12px] text-muted-foreground">시세 순위</p>
+                        <p className="text-xl font-bold mt-0.5">
+                          <span className="text-primary">{rankData.data.myRank}</span>
+                          <span className="text-[13px] font-normal text-muted-foreground">/{rankData.data.totalInRegion}</span>
+                        </p>
+                        <p className="text-[11px] text-muted-foreground">상위 {rankData.data.percentile}%</p>
+                      </div>
+                      {/* 평당가 */}
+                      <div className="text-center">
+                        <p className="text-[12px] text-muted-foreground">평당가</p>
+                        <p className="text-xl font-bold mt-0.5">
+                          {rankData.data.myAvgPpp.toLocaleString()}
+                        </p>
+                        <p className="text-[11px] text-muted-foreground">만원/평</p>
+                      </div>
+                      {/* 회전율 */}
+                      <div className="text-center">
+                        <p className="text-[12px] text-muted-foreground">회전율</p>
+                        {rankData.data.turnoverRate !== null ? (
+                          <>
+                            <p className="text-xl font-bold mt-0.5">{rankData.data.turnoverRate}%</p>
+                            <p className="text-[11px] text-muted-foreground">
+                              {rankData.data.recentTrades}건/{rankData.data.totalUnits}세대
+                            </p>
+                          </>
+                        ) : (
+                          <p className="text-[14px] font-medium text-muted-foreground mt-1">—</p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
+
                 {/* 면적별 필터 칩 */}
                 {areaGroups.length > 1 && (
                   <div className="px-5 py-3 border-b">

--- a/src/app/api/market/apartments/[id]/rank/route.ts
+++ b/src/app/api/market/apartments/[id]/rank/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { pricePerPyeong } from '@/lib/calculations';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/market/apartments/[id]/rank
+ * 같은 지역 내 시세 순위 + 회전율
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const complex = await prisma.apartmentComplex.findUnique({
+    where: { id },
+    select: {
+      name: true,
+      regionCode: true,
+      totalUnits: true,
+      trades: {
+        select: { price: true, area: true, dealDate: true },
+        orderBy: { dealDate: 'desc' },
+        take: 50,
+      },
+    },
+  });
+
+  if (!complex || complex.trades.length === 0) {
+    return NextResponse.json({ data: null });
+  }
+
+  const myAvgPpp = Math.round(
+    complex.trades.reduce((s, t) => s + pricePerPyeong(t.price, t.area), 0) / complex.trades.length
+  );
+
+  // 같은 지역 내 모든 단지의 평당가
+  const siblings = await prisma.apartmentComplex.findMany({
+    where: {
+      regionCode: complex.regionCode,
+      trades: { some: {} },
+    },
+    select: {
+      id: true,
+      name: true,
+      totalUnits: true,
+      trades: {
+        select: { price: true, area: true },
+        orderBy: { dealDate: 'desc' },
+        take: 20,
+      },
+    },
+  });
+
+  const ranked = siblings
+    .map((s) => {
+      const avgPpp = Math.round(
+        s.trades.reduce((sum, t) => sum + pricePerPyeong(t.price, t.area), 0) / s.trades.length
+      );
+      return { id: s.id, name: s.name, avgPpp, tradeCount: s.trades.length, totalUnits: s.totalUnits };
+    })
+    .sort((a, b) => b.avgPpp - a.avgPpp);
+
+  const myRank = ranked.findIndex((r) => r.id === id) + 1;
+  const totalInRegion = ranked.length;
+  const percentile = Math.round((1 - (myRank - 1) / totalInRegion) * 100);
+
+  // 회전율: 최근 1년 거래 건수 / 세대수
+  const oneYearAgo = new Date();
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+  const recentTrades = complex.trades.filter((t) => new Date(t.dealDate) >= oneYearAgo).length;
+  const turnoverRate = complex.totalUnits && complex.totalUnits > 0
+    ? Math.round((recentTrades / complex.totalUnits) * 100)
+    : null;
+
+  // 상위/하위 3개
+  const top3 = ranked.slice(0, 3);
+  const nearMe = ranked.slice(Math.max(0, myRank - 2), myRank + 1);
+
+  return NextResponse.json({
+    data: {
+      myRank,
+      totalInRegion,
+      percentile,
+      myAvgPpp,
+      turnoverRate,
+      recentTrades,
+      totalUnits: complex.totalUnits,
+      top3,
+      nearMe,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- 호갱노노 참고 — 동네 시세 순위, 회전율, TOP 3 기능 추가

## Changes
- **순위 API** (`/api/market/apartments/[id]/rank`): 같은 지역 내 평당가 순위, 상위 %, TOP 3
- **회전율**: 최근 1년 거래 건수 / 세대수 (%), 10%+ 빨강, 5%+ 앰버, 그 외 블루
- **지도 패널**: 개요 탭 상단에 순위/평당가/회전율 3열 카드
- **상세 페이지**: RankCard 컴포넌트 (순위 카드 + 지역 TOP 3)

## Test plan
- [ ] 지도에서 단지 선택 → 순위/회전율 표시
- [ ] 상세 페이지 → RankCard 표시
- [ ] TOP 3 리스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)